### PR TITLE
Fix an AttributeError

### DIFF
--- a/okonomiyaki/repositories/grits.py
+++ b/okonomiyaki/repositories/grits.py
@@ -69,7 +69,7 @@ class GritsEggEntry(HasTraits):
         else:
             raise NotImplementedError(
                 "Tags for repository type '{}' not implemented yet".
-                format(self.repository))
+                format(self.repository_type))
 
     @property
     def grits_metadata(self):


### PR DESCRIPTION
`GritsEggEntry` has no attribute `repository`, it is `repository_type`.
I came across this error when I was trying to add a new repo type called `experimental`, and instead of raising the desired `NotImplementedError`, it raised an `AttributeError`.