### PR TITLE
ENH: handle eggs with C extensions.

### DIFF
--- a/okonomiyaki/file_formats/setuptools_egg.py
+++ b/okonomiyaki/file_formats/setuptools_egg.py
@@ -2,17 +2,35 @@ import re
 
 from okonomiyaki.errors import OkonomiyakiError
 
+
 _R_EGG_NAME = re.compile("""
         (?P<name>^[^.-]+)
-        (-(?P<version>[^-]+))?
-        (-py(?P<pyver>(\d+\.\d+)))?
+        (-(?P<version>[^-]+))
+        (-py(?P<pyver>(\d+\.\d+)))
+        (-(?P<platform>[^.]+))?
         \.egg
 """, re.VERBOSE)
 
+
 def parse_filename(path):
+    """
+    Parse a setuptools egg.
+
+    Returns
+    -------
+    name : str
+        the egg name
+    version : str
+        the egg version
+    python_version : str
+        the python version
+    platform : str or None
+        the platform string, or None for platform-independent eggs.
+    """
     m = _R_EGG_NAME.search(path)
     if m:
-        return m.group("name"), m.group("version"), m.group("pyver"), None
+        platform = m.group("platform")
+        return (m.group("name"), m.group("version"), m.group("pyver"),
+                platform)
     else:
         raise OkonomiyakiError("Invalid egg name: {0}".format(path))
-

--- a/okonomiyaki/file_formats/tests/test_setuptools_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_setuptools_file_format.py
@@ -15,12 +15,26 @@ class TestEggBuilder(unittest.TestCase):
         path = "nose-1.2.1-py2.6.egg"
 
         # When
-        name, version, pyver, _ = parse_filename(path)
+        name, version, pyver, platform = parse_filename(path)
 
         # Then
         self.assertEqual(name, "nose")
         self.assertEqual(version, "1.2.1")
         self.assertEqual(pyver, "2.6")
+        self.assertIsNone(platform)
+
+    def test_simple_with_extension(self):
+        # Given
+        path = "numpy-1.9.1-py2.6-win-amd64.egg"
+
+        # When
+        name, version, pyver, platform = parse_filename(path)
+
+        # Then
+        self.assertEqual(name, "numpy")
+        self.assertEqual(version, "1.9.1")
+        self.assertEqual(pyver, "2.6")
+        self.assertEqual(platform, "win-amd64")
 
     def test_enthought_egg(self):
         # Given


### PR DESCRIPTION
Add support for parsing egg filenames with C extension (e.g. `PyYAML-3.11-py2.7-win-amd64.egg`).

@sjagoe 
