### PR TITLE
Fix _guess_architecture for OSX i386/64bit.

### DIFF
--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -183,6 +183,9 @@ def _guess_architecture():
             return amd64
     elif machine in ("x86", "i386", "i686") and bits == "32bit":
         return x86
+    elif platform.system() == 'Darwin' and \
+             machine == "i386" and bits == "64bit":  # Yes, this is possible on OSX
+        return amd64
     else:
         raise OkonomiyakiError("Unknown bits/machine combination {0}/{1}".
                                format(bits, machine))

--- a/okonomiyaki/platforms/platform.py
+++ b/okonomiyaki/platforms/platform.py
@@ -209,6 +209,9 @@ def _guess_architecture():
             return Arch.from_name(X86_64)
     elif machine in ("x86", "i386", "i686") and bits == "32bit":
         return Arch.from_name(X86)
+    elif platform.system() == 'Darwin' and \
+         machine == "i386" and bits == "64bit":  # Yes, this is possible on OSX
+        return Arch.from_name(X86_64)
     else:
         raise OkonomiyakiError("Unknown bits/machine combination {0}/{1}".
                                format(bits, machine))


### PR DESCRIPTION
On OSX it is possible for machine to be 'i386' and architecture to be '64bit', for example on the Austin Jenkins Mac builder slave. This change adds a condition to handle that case.