### PR TITLE
Add platform filtering

### DIFF
--- a/okonomiyaki/platforms/__init__.py
+++ b/okonomiyaki/platforms/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
-from .epd_platform import EPD_PLATFORM_SHORT_NAMES, PLATFORM_NAMES, EPDPlatform, applies
+from .epd_platform import EPDPlatform, applies
+from .platform import Platform
 
 # Other variables above will hopefully disappear before v1
-__all__ = ["EPDPlatform"]
+__all__ = ["EPDPlatform", "Platform"]

--- a/okonomiyaki/platforms/platform.py
+++ b/okonomiyaki/platforms/platform.py
@@ -58,6 +58,16 @@ class Arch(HasTraits):
     """
 
     @classmethod
+    def _from_bidwith(cls, bitwidth):
+        if bitwidth == "32":
+            return cls.from_name(X86)
+        elif bitwidth == "64":
+            return cls.from_name(X86_64)
+        else:
+            msg = "Invalid bits width: {0!r}".format(bitwidth)
+            raise OkonomiyakiError(msg)
+
+    @classmethod
     def from_name(cls, name):
         return cls(name, _ARCH_NAME_TO_BITS[name])
 
@@ -162,13 +172,7 @@ class Platform(HasTraits):
         parts = s.split("-")
         if len(parts) == 2:
             name, bits = parts
-            if bits == "32":
-                arch = machine = Arch.from_name(X86)
-            elif bits == "64":
-                arch = machine = Arch.from_name(X86_64)
-            else:
-                msg = "Invalid bits width: {0!r}".format(bits)
-                raise OkonomiyakiError(msg)
+            arch = machine = Arch._from_bidwith(bits)
             os, name, family, release = _epd_name_to_quadruplet(name)
             return cls(os, name, family, arch, machine, release)
         elif len(parts) == 1:

--- a/okonomiyaki/platforms/platform.py
+++ b/okonomiyaki/platforms/platform.py
@@ -159,7 +159,9 @@ class Platform(HasTraits):
         e.g. 'rh5-32', or 'osx'
         """
         def _epd_name_to_quadruplet(name):
-            if name == "rh5":
+            if name == "rh6":
+                return (LINUX, RHEL, RHEL, "6.5")
+            elif name == "rh5":
                 return (LINUX, RHEL, RHEL, "5.8")
             elif name == "osx":
                 return (DARWIN, MAC_OS_X, MAC_OS_X, "10.6")

--- a/okonomiyaki/platforms/platform.py
+++ b/okonomiyaki/platforms/platform.py
@@ -58,7 +58,7 @@ class Arch(HasTraits):
     """
 
     @classmethod
-    def _from_bidwith(cls, bitwidth):
+    def _from_bitwidth(cls, bitwidth):
         if bitwidth == "32":
             return cls.from_name(X86)
         elif bitwidth == "64":
@@ -174,7 +174,7 @@ class Platform(HasTraits):
         parts = s.split("-")
         if len(parts) == 2:
             name, bits = parts
-            arch = machine = Arch._from_bidwith(bits)
+            arch = machine = Arch._from_bitwidth(bits)
             os, name, family, release = _epd_name_to_quadruplet(name)
             return cls(os, name, family, arch, machine, release)
         elif len(parts) == 1:

--- a/okonomiyaki/platforms/platform_filters.py
+++ b/okonomiyaki/platforms/platform_filters.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+from okonomiyaki.bundled.traitlets import HasTraits, Enum, Instance, Unicode
+
+from .platform import DARWIN, LINUX, SOLARIS, WINDOWS
+from .platform import CENTOS, RHEL, DEBIAN, UBUNTU, MAC_OS_X
+from .platform import Arch
+
+
+class PlatformLabel(HasTraits):
+    """
+    A platform filter.
+    """
+
+    os = Enum([WINDOWS, LINUX, DARWIN, SOLARIS, None])
+    """
+    The most generic OS description
+    """
+
+    name = Enum([WINDOWS, CENTOS, RHEL, DEBIAN, UBUNTU, MAC_OS_X, SOLARIS,
+                 None])
+    """
+    The most specific platform description
+    """
+
+    family = Enum([WINDOWS, RHEL, DEBIAN, MAC_OS_X, SOLARIS, None])
+    """
+    The 'kind' of platforms. For example, both debian and ubuntu distributions
+    share the same kind, 'debian'.
+    """
+
+    release = Unicode()
+    """
+    The release string. May be empty
+    """
+
+    arch = Instance(Arch)
+    """
+    Actual architecture. May be None.
+    """
+
+    def matches(self, platform):
+        """ Returns True if the given platform matches this label."""
+        if self.os and not platform.os == self.os:
+            return False
+
+        if self.family and not platform.family == self.family:
+            return False
+
+        if self.name and not platform.name == self.name:
+            return False
+
+        if self.release and not platform.release == self.release:
+            return False
+
+        if self.arch and not platform.arch == self.arch:
+            return False
+
+        return True

--- a/okonomiyaki/platforms/platform_filters.py
+++ b/okonomiyaki/platforms/platform_filters.py
@@ -57,7 +57,7 @@ class PlatformLabel(HasTraits):
         parts = s.split("-")
         if len(parts) == 2:
             name, bits = parts
-            arch = Arch._from_bidwith(bits)
+            arch = Arch._from_bitwidth(bits)
             os, name, family, release = _epd_name_to_quadruplet(name)
             return cls(os, name, family, arch, release)
         elif len(parts) == 1:
@@ -65,7 +65,7 @@ class PlatformLabel(HasTraits):
             if parts[0] == "all":
                 return cls()
             elif parts[0] in ("32", "64"):
-                arch = Arch._from_bidwith(parts[0])
+                arch = Arch._from_bitwidth(parts[0])
                 return cls(arch=arch)
             else:
                 arch = None

--- a/okonomiyaki/platforms/platform_filters.py
+++ b/okonomiyaki/platforms/platform_filters.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
-from okonomiyaki.bundled.traitlets import HasTraits, Enum, Instance, Unicode
+from okonomiyaki.bundled.traitlets import (HasTraits, Bool, Enum, Instance,
+                                           List, Unicode)
 
 from .platform import DARWIN, LINUX, SOLARIS, WINDOWS
 from .platform import CENTOS, RHEL, DEBIAN, UBUNTU, MAC_OS_X
@@ -55,5 +56,31 @@ class PlatformLabel(HasTraits):
 
         if self.arch and not platform.arch == self.arch:
             return False
+
+        return True
+
+
+class PlatformLiteral(HasTraits):
+    label = Instance(PlatformLabel)
+    is_true = Bool(True)
+
+    def __init__(self, label, is_true=True):
+        super(PlatformLiteral, self).__init__(label=label, is_true=is_true)
+
+
+class PlatformFilter(HasTraits):
+    platform_labels = List(Instance(PlatformLiteral))
+
+    def __init__(self, labels):
+        super(PlatformFilter, self).__init__(platform_labels=labels)
+
+    def matches(self, platform):
+        for platform_label in self.platform_labels:
+            if ((platform_label.is_true
+                 and not platform_label.label.matches(platform))
+                or
+                (not platform_label.is_true
+                 and platform_label.label.matches(platform))):
+                return False
 
         return True

--- a/okonomiyaki/platforms/platform_filters.py
+++ b/okonomiyaki/platforms/platform_filters.py
@@ -110,6 +110,23 @@ class PlatformLiteral(HasTraits):
 class PlatformFilter(HasTraits):
     platform_labels = List(Instance(PlatformLiteral))
 
+    @classmethod
+    def from_legacy_string(cls, s):
+        """ Create a filter from a legacy pisi string, e.g. `!win'.
+        """
+        parts = [p.strip() for p in s.split(",")]
+        literals = []
+        for part in parts:
+            if part.startswith("!"):
+                label = PlatformLabel._from_legacy_string(part[1:])
+                literal = PlatformLiteral(label, False)
+            else:
+                label = PlatformLabel._from_legacy_string(part)
+                literal = PlatformLiteral(label, True)
+            literals.append(literal)
+
+        return cls(literals)
+
     def __init__(self, labels):
         super(PlatformFilter, self).__init__(platform_labels=labels)
 

--- a/okonomiyaki/platforms/platform_filters.py
+++ b/okonomiyaki/platforms/platform_filters.py
@@ -81,19 +81,19 @@ class PlatformLabel(HasTraits):
 
     def matches(self, platform):
         """ Returns True if the given platform matches this label."""
-        if self.os and not platform.os == self.os:
+        if self.os and platform.os != self.os:
             return False
 
-        if self.family and not platform.family == self.family:
+        if self.family and platform.family != self.family:
             return False
 
-        if self.name and not platform.name == self.name:
+        if self.name and platform.name != self.name:
             return False
 
-        if self.release and not platform.release == self.release:
+        if self.release and platform.release != self.release:
             return False
 
-        if self.arch and not platform.arch == self.arch:
+        if self.arch and platform.arch != self.arch:
             return False
 
         return True

--- a/okonomiyaki/platforms/tests/test_epd_platform.py
+++ b/okonomiyaki/platforms/tests/test_epd_platform.py
@@ -3,9 +3,11 @@ import unittest
 
 from okonomiyaki.errors import OkonomiyakiError
 
-from okonomiyaki.platforms import EPD_PLATFORM_SHORT_NAMES, EPDPlatform
+from okonomiyaki.platforms import EPDPlatform
 from okonomiyaki.platforms.epd_platform import (_guess_architecture,
-                                                _guess_epd_platform, applies)
+                                                _guess_epd_platform,
+                                                EPD_PLATFORM_SHORT_NAMES,
+                                                applies)
 from okonomiyaki.platforms.legacy import _SUBDIR
 
 from .common import (mock_centos_3_5, mock_centos_5_8, mock_centos_6_3,

--- a/okonomiyaki/platforms/tests/test_platform.py
+++ b/okonomiyaki/platforms/tests/test_platform.py
@@ -2,6 +2,7 @@ import unittest
 
 from okonomiyaki.errors import OkonomiyakiError
 from ..platform import Arch, Platform
+from ..platform import DARWIN, LINUX, MAC_OS_X, RHEL, WINDOWS, X86, X86_64
 
 from .common import (mock_machine_armv71, mock_x86, mock_x86_64,
                      mock_x86_on_x86_64, mock_machine_x86_64)
@@ -322,3 +323,90 @@ class TestPlatform(unittest.TestCase):
         self.assertFalse(win32_1 == win64)
 
         self.assertNotEqual(win32_1, None)
+
+    def test_from_epd_platform_string(self):
+        # Given
+        epd_platform_string = "rh5-32"
+
+        # When
+        platform = Platform.from_epd_platform_string(epd_platform_string)
+
+        # Then
+        self.assertEqual(platform.os, LINUX)
+        self.assertEqual(platform.family, RHEL)
+        self.assertEqual(platform.name, RHEL)
+        self.assertEqual(platform.arch, Arch.from_name(X86))
+        self.assertEqual(platform.machine, Arch.from_name(X86))
+
+        # Given
+        epd_platform_string = "win-32"
+
+        # When
+        platform = Platform.from_epd_platform_string(epd_platform_string)
+
+        # Then
+        self.assertEqual(platform.os, WINDOWS)
+        self.assertEqual(platform.family, WINDOWS)
+        self.assertEqual(platform.name, WINDOWS)
+        self.assertEqual(platform.arch, Arch.from_name(X86))
+        self.assertEqual(platform.machine, Arch.from_name(X86))
+
+        # Given
+        epd_platform_string = "osx-64"
+
+        # When
+        platform = Platform.from_epd_platform_string(epd_platform_string)
+
+        # Then
+        self.assertEqual(platform.os, DARWIN)
+        self.assertEqual(platform.family, MAC_OS_X)
+        self.assertEqual(platform.name, MAC_OS_X)
+        self.assertEqual(platform.arch, Arch.from_name(X86_64))
+        self.assertEqual(platform.machine, Arch.from_name(X86_64))
+
+        # Given
+        epd_platform_string = "osx"
+
+        # When
+        with mock_x86_64:
+            platform = Platform.from_epd_platform_string(epd_platform_string)
+
+        # Then
+        self.assertEqual(platform.os, DARWIN)
+        self.assertEqual(platform.family, MAC_OS_X)
+        self.assertEqual(platform.name, MAC_OS_X)
+        self.assertEqual(platform.arch, Arch.from_name(X86_64))
+        self.assertEqual(platform.machine, Arch.from_name(X86_64))
+
+        # When
+        with mock_x86:
+            platform = Platform.from_epd_platform_string(epd_platform_string)
+
+        # Then
+        self.assertEqual(platform.arch, Arch.from_name(X86))
+        self.assertEqual(platform.machine, Arch.from_name(X86))
+
+    def test_from_epd_platform_string_invalid(self):
+        # Given
+        # Invalid bitwidth
+        epd_platform_string = "linux-32-1"
+
+        # When/Then
+        with self.assertRaises(OkonomiyakiError):
+            Platform.from_epd_platform_string(epd_platform_string)
+
+        # Given
+        # Invalid bitwidth
+        epd_platform_string = "osx-63"
+
+        # When/Then
+        with self.assertRaises(OkonomiyakiError):
+            Platform.from_epd_platform_string(epd_platform_string)
+
+        # Given
+        # Invalid platform basename
+        epd_platform_string = "netbsd-32"
+
+        # When/Then
+        with self.assertRaises(OkonomiyakiError):
+            Platform.from_epd_platform_string(epd_platform_string)

--- a/okonomiyaki/platforms/tests/test_platform_filters.py
+++ b/okonomiyaki/platforms/tests/test_platform_filters.py
@@ -3,7 +3,14 @@ from __future__ import absolute_import
 import unittest
 
 from ..platform import Arch, Platform
-from ..platform_filters import PlatformLabel
+from ..platform_filters import PlatformFilter, PlatformLabel, PlatformLiteral
+
+LABEL_WINDOWS_ANY = PlatformLabel()
+LABEL_WINDOWS_ANY.os = "windows"
+
+LABEL_OSX_32 = PlatformLabel()
+LABEL_OSX_32.os = "darwin"
+LABEL_OSX_32.arch = Arch.from_name("x86")
 
 RH5_32 = Platform.from_epd_platform_string("rh5-32")
 RH5_64 = Platform.from_epd_platform_string("rh5-64")
@@ -62,3 +69,16 @@ class TestPlatformLabel(unittest.TestCase):
         self.assertFalse(label.matches(UBUNTU_12_10_X32))
         self.assertTrue(label.matches(UBUNTU_14_04_X32))
         self.assertFalse(label.matches(UBUNTU_14_04_X64))
+
+
+class TestPlatformFilter(unittest.TestCase):
+    def test_conjonction(self):
+        # Given
+        literals = [PlatformLiteral(LABEL_WINDOWS_ANY, False),
+                    PlatformLiteral(LABEL_OSX_32, False)]
+
+        # When
+        filtre = PlatformFilter(literals)
+
+        # Then
+        self.assertTrue(filtre.matches(RH5_64))

--- a/okonomiyaki/platforms/tests/test_platform_filters.py
+++ b/okonomiyaki/platforms/tests/test_platform_filters.py
@@ -133,7 +133,7 @@ class TestPlatformLabel(unittest.TestCase):
 
 
 class TestPlatformFilter(unittest.TestCase):
-    def test_conjonction(self):
+    def test_simple(self):
         # Given
         literals = [PlatformLiteral(LABEL_WINDOWS_ANY, False),
                     PlatformLiteral(LABEL_OSX_32, False)]
@@ -143,3 +143,64 @@ class TestPlatformFilter(unittest.TestCase):
 
         # Then
         self.assertTrue(filtre.matches(RH5_64))
+
+    def test_from_pisi_string_simple(self):
+        # Given
+        legacy_string = "all"
+
+        # When
+        filtre = PlatformFilter.from_legacy_string(legacy_string)
+
+        # Then
+        self.assertTrue(filtre.matches(RH5_32))
+        self.assertTrue(filtre.matches(RH5_64))
+        self.assertTrue(filtre.matches(OSX_32))
+        self.assertTrue(filtre.matches(WIN_64))
+        self.assertTrue(filtre.matches(UBUNTU_12_10_X32))
+        self.assertTrue(filtre.matches(UBUNTU_14_04_X32))
+        self.assertTrue(filtre.matches(UBUNTU_14_04_X64))
+
+        # Given
+        legacy_string = "!all"
+
+        # When
+        filtre = PlatformFilter.from_legacy_string(legacy_string)
+
+        # Then
+        self.assertFalse(filtre.matches(RH5_32))
+        self.assertFalse(filtre.matches(RH5_64))
+        self.assertFalse(filtre.matches(OSX_32))
+        self.assertFalse(filtre.matches(WIN_64))
+        self.assertFalse(filtre.matches(UBUNTU_12_10_X32))
+        self.assertFalse(filtre.matches(UBUNTU_14_04_X32))
+        self.assertFalse(filtre.matches(UBUNTU_14_04_X64))
+
+        # Given
+        legacy_string = "win"
+
+        # When
+        filtre = PlatformFilter.from_legacy_string(legacy_string)
+
+        # Then
+        self.assertFalse(filtre.matches(RH5_32))
+        self.assertFalse(filtre.matches(RH5_64))
+        self.assertFalse(filtre.matches(OSX_32))
+        self.assertTrue(filtre.matches(WIN_64))
+        self.assertFalse(filtre.matches(UBUNTU_12_10_X32))
+        self.assertFalse(filtre.matches(UBUNTU_14_04_X32))
+
+    def test_from_pisi_string_composite(self):
+        # Given
+        legacy_string = "!win,!osx"
+
+        # When
+        filtre = PlatformFilter.from_legacy_string(legacy_string)
+
+        # Then
+        self.assertTrue(filtre.matches(RH5_32))
+        self.assertTrue(filtre.matches(RH5_64))
+        self.assertFalse(filtre.matches(OSX_32))
+        self.assertFalse(filtre.matches(WIN_64))
+        self.assertTrue(filtre.matches(UBUNTU_12_10_X32))
+        self.assertTrue(filtre.matches(UBUNTU_14_04_X32))
+        self.assertTrue(filtre.matches(UBUNTU_14_04_X64))

--- a/okonomiyaki/platforms/tests/test_platform_filters.py
+++ b/okonomiyaki/platforms/tests/test_platform_filters.py
@@ -1,0 +1,64 @@
+from __future__ import absolute_import
+
+import unittest
+
+from ..platform import Arch, Platform
+from ..platform_filters import PlatformLabel
+
+RH5_32 = Platform.from_epd_platform_string("rh5-32")
+RH5_64 = Platform.from_epd_platform_string("rh5-64")
+OSX_32 = Platform.from_epd_platform_string("osx-32")
+WIN_64 = Platform.from_epd_platform_string("win-64")
+
+UBUNTU_12_10_X32 = Platform("linux", "ubuntu", "debian", Arch.from_name("x86"),
+                            release="12.10")
+UBUNTU_14_04_X32 = Platform("linux", "ubuntu", "debian", Arch.from_name("x86"),
+                            release="14.04")
+UBUNTU_14_04_X64 = Platform("linux", "ubuntu", "debian",
+                            Arch.from_name("x86_64"), release="14.04")
+
+
+class TestPlatformLabel(unittest.TestCase):
+    def test_bitwidth_only(self):
+        # Given
+        label = PlatformLabel(arch=Arch.from_name("x86"))
+
+        # When/Then
+        self.assertTrue(label.matches(RH5_32))
+        self.assertFalse(label.matches(RH5_64))
+        self.assertTrue(label.matches(OSX_32))
+        self.assertFalse(label.matches(WIN_64))
+
+    def test_os(self):
+        # Given
+        label = PlatformLabel(os="windows")
+
+        # When/Then
+        self.assertFalse(label.matches(RH5_32))
+        self.assertFalse(label.matches(RH5_64))
+        self.assertFalse(label.matches(OSX_32))
+        self.assertTrue(label.matches(WIN_64))
+
+    def test_name(self):
+        # Given
+        label = PlatformLabel(name="centos")
+
+        # When/Then
+        self.assertFalse(label.matches(RH5_32))
+        self.assertFalse(label.matches(RH5_64))
+        self.assertFalse(label.matches(OSX_32))
+        self.assertFalse(label.matches(WIN_64))
+
+    def test_specific(self):
+        # Given
+        label = PlatformLabel(name="ubuntu", arch=Arch.from_name("x86"),
+                              release="14.04")
+
+        # When/Then
+        self.assertFalse(label.matches(RH5_32))
+        self.assertFalse(label.matches(RH5_64))
+        self.assertFalse(label.matches(OSX_32))
+        self.assertFalse(label.matches(WIN_64))
+        self.assertFalse(label.matches(UBUNTU_12_10_X32))
+        self.assertTrue(label.matches(UBUNTU_14_04_X32))
+        self.assertFalse(label.matches(UBUNTU_14_04_X64))

--- a/okonomiyaki/platforms/tests/test_platform_filters.py
+++ b/okonomiyaki/platforms/tests/test_platform_filters.py
@@ -70,6 +70,67 @@ class TestPlatformLabel(unittest.TestCase):
         self.assertTrue(label.matches(UBUNTU_14_04_X32))
         self.assertFalse(label.matches(UBUNTU_14_04_X64))
 
+    def test_from_legacy_string(self):
+        # Given
+        label = PlatformLabel._from_legacy_string("rh")
+
+        # When/Then
+        self.assertTrue(label.matches(RH5_32))
+        self.assertTrue(label.matches(RH5_64))
+        self.assertFalse(label.matches(OSX_32))
+        self.assertFalse(label.matches(WIN_64))
+        self.assertFalse(label.matches(UBUNTU_12_10_X32))
+        self.assertFalse(label.matches(UBUNTU_14_04_X32))
+        self.assertFalse(label.matches(UBUNTU_14_04_X64))
+
+        # Given
+        label = PlatformLabel._from_legacy_string("rh6")
+
+        # When/Then
+        self.assertFalse(label.matches(RH5_32))
+        self.assertFalse(label.matches(RH5_64))
+        self.assertFalse(label.matches(OSX_32))
+        self.assertFalse(label.matches(WIN_64))
+        self.assertFalse(label.matches(UBUNTU_12_10_X32))
+        self.assertFalse(label.matches(UBUNTU_14_04_X32))
+        self.assertFalse(label.matches(UBUNTU_14_04_X64))
+
+        # Given
+        label = PlatformLabel._from_legacy_string("win-64")
+
+        # When/Then
+        self.assertFalse(label.matches(RH5_32))
+        self.assertFalse(label.matches(RH5_64))
+        self.assertFalse(label.matches(OSX_32))
+        self.assertTrue(label.matches(WIN_64))
+        self.assertFalse(label.matches(UBUNTU_12_10_X32))
+        self.assertFalse(label.matches(UBUNTU_14_04_X32))
+        self.assertFalse(label.matches(UBUNTU_14_04_X64))
+
+        # Given
+        label = PlatformLabel._from_legacy_string("64")
+
+        # When/Then
+        self.assertFalse(label.matches(RH5_32))
+        self.assertTrue(label.matches(RH5_64))
+        self.assertFalse(label.matches(OSX_32))
+        self.assertTrue(label.matches(WIN_64))
+        self.assertFalse(label.matches(UBUNTU_12_10_X32))
+        self.assertFalse(label.matches(UBUNTU_14_04_X32))
+        self.assertTrue(label.matches(UBUNTU_14_04_X64))
+
+        # Given
+        label = PlatformLabel._from_legacy_string("all")
+
+        # When/Then
+        self.assertTrue(label.matches(RH5_32))
+        self.assertTrue(label.matches(RH5_64))
+        self.assertTrue(label.matches(OSX_32))
+        self.assertTrue(label.matches(WIN_64))
+        self.assertTrue(label.matches(UBUNTU_12_10_X32))
+        self.assertTrue(label.matches(UBUNTU_14_04_X32))
+        self.assertTrue(label.matches(UBUNTU_14_04_X64))
+
 
 class TestPlatformFilter(unittest.TestCase):
     def test_conjonction(self):

--- a/okonomiyaki/repositories/grits.py
+++ b/okonomiyaki/repositories/grits.py
@@ -1,8 +1,7 @@
 from ..bundled.traitlets import HasTraits, Enum, Instance
 from ..errors import OkonomiyakiError
 from ..file_formats.egg import egg_name, split_egg_name
-from ..platforms import EPD_PLATFORM_SHORT_NAMES
-from ..platforms.epd_platform import EPDPlatform
+from ..platforms.epd_platform import EPD_PLATFORM_SHORT_NAMES, EPDPlatform
 
 from .enpkg import EnpkgS3IndexEntry
 


### PR DESCRIPTION
This adds code so that we can easily filter on platforms using the pisi legacy (e.g. `platforms=all`, or `platforms=!win`) in a way that is "typed" and amenable to additional platforms