### PR TITLE
BUG: fix handling of unsupported metadata version.

### DIFF
--- a/okonomiyaki/file_formats/_package_info.py
+++ b/okonomiyaki/file_formats/_package_info.py
@@ -8,6 +8,9 @@ import zipfile2
 
 from six.moves import StringIO
 
+from ..errors import OkonomiyakiError
+
+
 _PKG_INFO_LOCATION = "EGG-INFO/PKG-INFO"
 
 PKG_INFO_ENCODING = 'utf-8'
@@ -169,7 +172,13 @@ class PackageInfo(object):
 
 
 def _get_header_attributes(metadata_version):
-    return HEADER_ATTRS.get(metadata_version, [])
+    attributes = HEADER_ATTRS.get(metadata_version)
+    if attributes is None:
+        msg = ("Unsupported PKG-INFO metadata format: {0!r}"
+               .format(metadata_version))
+        raise OkonomiyakiError(msg)
+    else:
+        return attributes
 
 
 def _parse(fp):

--- a/okonomiyaki/file_formats/tests/test__package_info.py
+++ b/okonomiyaki/file_formats/tests/test__package_info.py
@@ -7,6 +7,7 @@ if sys.version_info[:2] < (2, 7):
 else:
     import unittest
 
+from ...errors import OkonomiyakiError
 from .common import (
     PIP_EGG, PKG_INFO_ENSTALLER_1_0_DESCRIPTION, PIP_PKG_INFO,
     PKG_INFO_ENSTALLER_1_0
@@ -47,6 +48,14 @@ class TestPackageInfo(unittest.TestCase):
         self.assertEqual(pkg_info.requires, ())
         self.assertEqual(pkg_info.provides, ())
         self.assertEqual(pkg_info.obsoletes, ())
+
+    def test_from_string_unsupported(self):
+        # Given
+        data = "Metadata-Version: 1.2"
+
+        # When/Then
+        with self.assertRaises(OkonomiyakiError):
+            PackageInfo.from_string(data)
 
     def test_simple_from_egg(self):
         # Given


### PR DESCRIPTION
Parsing a `PKG-INFO` was causing `KeyError` exceptions for unsupported versions.