### PR TITLE
Add platform tag

### DIFF
--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -524,30 +524,10 @@ def _guess_platform_tag(platform):
     if platform is None:
         return None
 
-    msg = "Cannot guess platform tag for platform {0!r}"
-
-    if platform.family == MAC_OS_X and platform.release == "10.6":
-        if platform.arch.name == X86:
-            return "macosx_10_6_i386"
-        elif platform.arch.name == X86_64:
-            return "macosx_10_6_x86_64"
-        else:
-            raise OkonomiyakiError(msg.format(platform))
-    elif platform.family == RHEL and platform.release == "5.8":
-        if platform.arch.name == X86:
-            return "linux_i686"
-        elif platform.arch.name == X86_64:
-            return "linux_x86_64"
-        else:
-            raise OkonomiyakiError(msg.format(platform))
-    elif platform.family == WINDOWS:
-        if platform.arch.name == X86:
-            return "win32"
-        elif platform.arch.name == X86_64:
-            return "win_amd64"
-        else:
-            raise OkonomiyakiError(msg.format(platform))
+    if _can_guess_for_pep425(platform):
+        return platform.pep425_tag
     else:
+        msg = "Cannot guess platform tag for platform {0!r}"
         raise OkonomiyakiError(msg.format(platform))
 
 
@@ -710,7 +690,6 @@ class EggMetadata(object):
         self.python_tag = python_tag
 
         self.abi_tag = abi_tag
-        self._platform_tag = _guess_platform_tag(platform)
 
         self.runtime_dependencies = tuple(dependencies.runtime)
 
@@ -746,7 +725,10 @@ class EggMetadata(object):
 
     @property
     def platform_tag(self):
-        return self._platform_tag
+        if self.platform is None:
+            return None
+        else:
+            return self.platform.pep425_tag
 
     @property
     def spec_depend_string(self):

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -521,6 +521,9 @@ def _guess_abi_tag(platform, python_tag):
 
 
 def _guess_platform_tag(platform):
+    if platform is None:
+        return None
+
     msg = "Cannot guess platform tag for platform {0!r}"
 
     if platform.family == MAC_OS_X and platform.release == "10.6":

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -12,7 +12,7 @@ from ..errors import (
 )
 from ..platforms import Platform
 from ..platforms.legacy import LegacyEPDPlatform
-from ..platforms.platform import MAC_OS_X, RHEL, WINDOWS, X86, X86_64
+from ..platforms.platform import MAC_OS_X, RHEL, WINDOWS
 from ..utils import parse_assignments
 from ..utils.traitlets import NoneOrInstance, NoneOrUnicode
 from ..versions import EnpkgVersion

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -427,6 +427,7 @@ osdist = None
 python = "2.7"
 python_tag = "cp27"
 abi_tag = "cp27m"
+platform_tag = "win32"
 
 packages = [
 ]
@@ -437,6 +438,7 @@ packages = [
         self.assertEqual(depend._metadata_version, "1.3")
         self.assertEqual(depend.python_tag, "cp27")
         self.assertEqual(depend.abi_tag, "cp27m")
+        self.assertEqual(depend.platform_tag, "win32")
 
 
 class TestLegacySpecDependAbi(unittest.TestCase):
@@ -543,6 +545,7 @@ python = '2.7'
 
 python_tag = 'cp27'
 abi_tag = 'cp27m'
+platform_tag = 'macosx_10_6_x86_64'
 
 packages = []
 """
@@ -569,6 +572,117 @@ packages = []
 
         # Then
         self.assertMultiLineEqual(spec_depend_string, r_spec_depend_string)
+
+
+class TestLegacySpecDependPlatform(unittest.TestCase):
+    def test_default_win_64(self):
+        # Given
+        spec_depend_string = """\
+metadata_version = '1.1'
+name = 'MKL'
+version = '10.3'
+build = 1
+
+arch = 'amd64'
+platform = 'win32'
+osdist = None
+
+python = None
+packages = []
+"""
+
+        # When
+        spec_depend = LegacySpecDepend.from_string(spec_depend_string)
+
+        # Then
+        self.assertEqual(spec_depend.platform_tag, "win_amd64")
+
+    def test_default_win_32(self):
+        # Given
+        spec_depend_string = """\
+metadata_version = '1.1'
+name = 'MKL'
+version = '10.3'
+build = 1
+
+arch = 'i386'
+platform = 'win32'
+osdist = None
+
+python = None
+packages = []
+"""
+
+        # When
+        spec_depend = LegacySpecDepend.from_string(spec_depend_string)
+
+        # Then
+        self.assertEqual(spec_depend.platform_tag, "win32")
+
+    def test_default_rh5_32(self):
+        # Given
+        spec_depend_string = """\
+metadata_version = '1.1'
+name = 'MKL'
+version = '10.3'
+build = 1
+
+arch = 'i386'
+platform = 'linux2'
+osdist = 'RedHat_5'
+
+python = None
+packages = []
+"""
+
+        # When
+        spec_depend = LegacySpecDepend.from_string(spec_depend_string)
+
+        # Then
+        self.assertEqual(spec_depend.platform_tag, "linux_i686")
+
+    def test_default_rh5_64(self):
+        # Given
+        spec_depend_string = """\
+metadata_version = '1.1'
+name = 'MKL'
+version = '10.3'
+build = 1
+
+arch = 'amd64'
+platform = 'linux2'
+osdist = 'RedHat_5'
+
+python = None
+packages = []
+"""
+
+        # When
+        spec_depend = LegacySpecDepend.from_string(spec_depend_string)
+
+        # Then
+        self.assertEqual(spec_depend.platform_tag, "linux_x86_64")
+
+    def test_default_all_none(self):
+        # Given
+        spec_depend_string = """\
+metadata_version = '1.1'
+name = 'MKL'
+version = '10.3'
+build = 1
+
+arch = None
+platform = None
+osdist = None
+python = None
+packages = []
+"""
+
+        # When
+        spec_depend = LegacySpecDepend.from_string(spec_depend_string)
+
+        # Then
+        self.assertIsNone(spec_depend.platform_tag)
 
 
 class TestEggName(unittest.TestCase):

--- a/okonomiyaki/platforms/platform.py
+++ b/okonomiyaki/platforms/platform.py
@@ -275,7 +275,7 @@ class Platform(HasTraits):
 
         if self.family == MAC_OS_X:
             if self.arch.name == X86:
-                return "macosx_{0}_i386".format(self.release, )
+                return "macosx_10_6_i386"
             elif self.arch.name == X86_64:
                 return "macosx_10_6_x86_64"
             else:

--- a/okonomiyaki/platforms/platform.py
+++ b/okonomiyaki/platforms/platform.py
@@ -269,6 +269,34 @@ class Platform(HasTraits):
             self._epd_platform_string
         )
 
+    @property
+    def pep425_tag(self):
+        msg = "Cannot guess platform tag for platform {0!r}"
+
+        if self.family == MAC_OS_X:
+            if self.arch.name == X86:
+                return "macosx_{0}_i386".format(self.release, )
+            elif self.arch.name == X86_64:
+                return "macosx_10_6_x86_64"
+            else:
+                raise OkonomiyakiError(msg.format(self))
+        elif self.os == LINUX:
+            if self.arch.name == X86:
+                return "linux_i686"
+            elif self.arch.name == X86_64:
+                return "linux_x86_64"
+            else:
+                raise OkonomiyakiError(msg.format(self))
+        elif self.family == WINDOWS:
+            if self.arch.name == X86:
+                return "win32"
+            elif self.arch.name == X86_64:
+                return "win_amd64"
+            else:
+                raise OkonomiyakiError(msg.format(self))
+        else:
+            raise OkonomiyakiError(msg.format(self))
+
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False


### PR DESCRIPTION
Add a `platform_tag` to `EggMetadata`.

Some potential design issues:

* how/where to handle the conversion between `None` and the string representation as per pep425. We could add an `pep425_tag` property that would do the conversion
* there may be a source of confusion between `platform` (an object representing the platform) and `platform_tag`.

@sjagoe 