### PR TITLE
Use objects for dependencies

### DIFF
--- a/okonomiyaki/errors.py
+++ b/okonomiyaki/errors.py
@@ -26,7 +26,7 @@ class InvalidMetadata(InvalidEggFormat):
         return self.message
 
 
-class InvalidDependencyString(InvalidEggFormat):
+class InvalidRequirementString(InvalidEggFormat):
     def __init__(self, dependency_string):
-        msg = "Invalid dependency string {0!r}".format(dependency_string)
-        super(InvalidDependencyString, self).__init__(msg)
+        msg = "Invalid requirement string {0!r}".format(dependency_string)
+        super(InvalidRequirementString, self).__init__(msg)

--- a/okonomiyaki/file_formats/__init__.py
+++ b/okonomiyaki/file_formats/__init__.py
@@ -6,7 +6,8 @@ At the moment, we only support the Enthought's egg format.
 """
 # flake8: noqa
 from ._egg_info import (
-    Dependencies, EggMetadata, egg_name, is_egg_name_valid, split_egg_name
+    Dependencies, EggMetadata, Requirement, egg_name, is_egg_name_valid,
+    split_egg_name
 )
 from ._package_info import PackageInfo
 from .egg import EggBuilder

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -208,6 +208,21 @@ class Requirement(HasTraits):
         else:
             return self.name
 
+    @property
+    def _key(self):
+        return (self.name, self.version_string, self.build_number)
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return False
+        return self._key == other._key
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __hash__(self):
+        return hash(self._key)
+
 
 _METADATA_TEMPLATES = {
     "1.1": """\
@@ -632,7 +647,7 @@ class EggMetadata(object):
             platform = EPDPlatform.from_epd_string(platform_string)
 
         dependencies = Dependencies(
-            tuple(str(dep) for dep in spec_depend.packages)
+            tuple(dep for dep in spec_depend.packages)
         )
 
         metadata_version_info = (
@@ -741,10 +756,7 @@ class EggMetadata(object):
             "python_tag": self.python_tag,
             "abi_tag": self.abi_tag,
             "platform_tag": self.platform_tag,
-            "packages": [
-                Requirement.from_spec_string(dep)
-                for dep in self.runtime_dependencies
-            ],
+            "packages": [p for p in self.runtime_dependencies],
             "_epd_legacy_platform": _epd_legacy_platform,
             "_metadata_version": ".".join(
                 str(i) for i in self.metadata_version_info

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -8,7 +8,7 @@ from ..bundled.traitlets import (
     HasTraits, Enum, Instance, List, Long, Unicode
 )
 from ..errors import (
-    InvalidDependencyString, InvalidEggName, InvalidMetadata
+    InvalidRequirementString, InvalidEggName, InvalidMetadata
 )
 from ..platforms import EPDPlatform
 from ..platforms.legacy import LegacyEPDPlatform
@@ -121,10 +121,9 @@ def is_egg_name_valid(s):
     return _EGG_NAME_RE.match(s) is not None
 
 
-class Dependency(HasTraits):
+class Requirement(HasTraits):
     """
-    Dependency model for entries in the package metadata inside
-    EGG-INFO/spec/depend
+    Model for entries in the package metadata inside EGG-INFO/spec/depend
     """
     name = Unicode()
     version_string = Unicode()
@@ -134,7 +133,7 @@ class Dependency(HasTraits):
         self.name = name
         self.version_string = version_string
         self.build_number = build_number
-        super(Dependency, self).__init__(self, name, version_string,
+        super(Requirement, self).__init__(self, name, version_string,
                                          build_number)
 
     @property
@@ -149,7 +148,7 @@ class Dependency(HasTraits):
     @classmethod
     def from_string(cls, s, strictness=2):
         """
-        Create a Dependency from string following a name-version-build
+        Create a Requirement from string following a name-version-build
         format.
 
         Parameters
@@ -176,14 +175,14 @@ class Dependency(HasTraits):
     @classmethod
     def from_spec_string(cls, s):
         """
-        Create a Dependency from a spec string (as used in
+        Create a Requirement from a spec string (as used in
         EGG-INFO/spec/depend).
         """
         parts = s.split()
         if len(parts) == 1:
             name = parts[0]
             if "-" in name:
-                raise InvalidDependencyString(name)
+                raise InvalidRequirementString(name)
             return cls(name=name)
         elif len(parts) == 2:
             name, version = parts
@@ -196,7 +195,7 @@ class Dependency(HasTraits):
             return cls(name=name, version_string=upstream,
                        build_number=build_number)
         else:
-            raise InvalidDependencyString(name)
+            raise InvalidRequirementString(name)
 
     def __str__(self):
         if len(self.version_string) > 0:
@@ -325,7 +324,7 @@ class LegacySpecDepend(HasTraits):
     Platform tag (as defined in PEP 425), except that 'any' is None.
     """
 
-    packages = List(Instance(Dependency))
+    packages = List(Instance(Requirement))
     """
     List of dependencies for this egg
     """
@@ -347,7 +346,7 @@ class LegacySpecDepend(HasTraits):
         args["_epd_legacy_platform"] = _epd_legacy_platform
 
         args[_TAG_PACKAGES] = [
-            Dependency.from_spec_string(s) for s in args.get(_TAG_PACKAGES, [])
+            Requirement.from_spec_string(s) for s in args.get(_TAG_PACKAGES, [])
         ]
 
         return cls(**args)
@@ -458,6 +457,10 @@ class LegacySpecDepend(HasTraits):
 
 
 class Dependencies(object):
+    """ Object storing the various dependencies for an egg.
+
+    Each attribute is a tuple of Requirement instances.
+    """
     def __init__(self, runtime=None, build=None):
         self.runtime = runtime or ()
         self.build = runtime or ()
@@ -739,7 +742,7 @@ class EggMetadata(object):
             "abi_tag": self.abi_tag,
             "platform_tag": self.platform_tag,
             "packages": [
-                Dependency.from_spec_string(dep)
+                Requirement.from_spec_string(dep)
                 for dep in self.runtime_dependencies
             ],
             "_epd_legacy_platform": _epd_legacy_platform,

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -16,7 +16,7 @@ import os.path as op
 from ...errors import InvalidEggName, InvalidMetadata
 from ..egg import EggBuilder
 from .._egg_info import (
-    Dependency, Dependencies, EggMetadata, LegacySpecDepend, parse_rawspec,
+    Requirement, Dependencies, EggMetadata, LegacySpecDepend, parse_rawspec,
     split_egg_name
 )
 from .._package_info import PackageInfo
@@ -242,68 +242,68 @@ packages = []
             self.assertEqual(set(fp.namelist()), set(r_files))
 
 
-class TestDependency(unittest.TestCase):
+class TestRequirement(unittest.TestCase):
     def test_str(self):
-        dependency = Dependency(name="numpy")
+        dependency = Requirement(name="numpy")
         r_str = "numpy"
 
         self.assertEqual(r_str, str(dependency))
 
-        dependency = Dependency(name="numpy", version_string="1.7.1")
+        dependency = Requirement(name="numpy", version_string="1.7.1")
         r_str = "numpy 1.7.1"
 
         self.assertEqual(r_str, str(dependency))
 
-        dependency = Dependency(name="numpy", version_string="1.7.1",
+        dependency = Requirement(name="numpy", version_string="1.7.1",
                                 build_number=1)
         r_str = "numpy 1.7.1-1"
 
         self.assertEqual(r_str, str(dependency))
 
-        dependency = Dependency("numpy", "1.7.1", 1)
+        dependency = Requirement("numpy", "1.7.1", 1)
         r_str = "numpy 1.7.1-1"
 
         self.assertEqual(r_str, str(dependency))
 
     def test_from_spec_string(self):
-        dependency = Dependency.from_spec_string("numpy")
+        dependency = Requirement.from_spec_string("numpy")
         self.assertEqual(dependency.name, "numpy")
         self.assertEqual(dependency.version_string, "")
         self.assertEqual(dependency.build_number, -1)
         self.assertEqual(dependency.strictness, 1)
 
-        dependency = Dependency.from_spec_string("numpy 1.7.1")
+        dependency = Requirement.from_spec_string("numpy 1.7.1")
         self.assertEqual(dependency.name, "numpy")
         self.assertEqual(dependency.version_string, "1.7.1")
         self.assertEqual(dependency.build_number, -1)
         self.assertEqual(dependency.strictness, 2)
 
-        dependency = Dependency.from_spec_string("numpy 1.7.1-2")
+        dependency = Requirement.from_spec_string("numpy 1.7.1-2")
         self.assertEqual(dependency.name, "numpy")
         self.assertEqual(dependency.version_string, "1.7.1")
         self.assertEqual(dependency.build_number, 2)
         self.assertEqual(dependency.strictness, 3)
 
     def test_from_string(self):
-        dependency = Dependency.from_string("numpy-1.7.1-2", 3)
+        dependency = Requirement.from_string("numpy-1.7.1-2", 3)
         self.assertEqual(dependency.name, "numpy")
         self.assertEqual(dependency.version_string, "1.7.1")
         self.assertEqual(dependency.build_number, 2)
 
-        dependency = Dependency.from_string("numpy-1.7.1-2", 2)
+        dependency = Requirement.from_string("numpy-1.7.1-2", 2)
         self.assertEqual(dependency.name, "numpy")
         self.assertEqual(dependency.version_string, "1.7.1")
         self.assertEqual(dependency.build_number, -1)
 
-        dependency = Dependency.from_string("numpy-1.7.1-2", 1)
+        dependency = Requirement.from_string("numpy-1.7.1-2", 1)
         self.assertEqual(dependency.name, "numpy")
         self.assertEqual(dependency.version_string, "")
         self.assertEqual(dependency.build_number, -1)
 
         self.assertRaises(InvalidEggName, lambda:
-                          Dependency.from_string("numpy"))
+                          Requirement.from_string("numpy"))
         self.assertRaises(InvalidEggName, lambda:
-                          Dependency.from_string("numpy 1.7.1"))
+                          Requirement.from_string("numpy 1.7.1"))
 
 
 class TestLegacySpecDepend(unittest.TestCase):

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -325,6 +325,7 @@ class TestLegacySpecDepend(unittest.TestCase):
         self.assertMultiLineEqual(spec_depend.to_string(), r_spec_depend)
 
     def test_from_string(self):
+        # Given
         r_depend = """\
 metadata_version = '1.1'
 name = 'Qt_debug'
@@ -339,9 +340,14 @@ packages = [
   'Qt 4.8.5',
 ]
 """
+
+        # When
         depend = LegacySpecDepend.from_string(r_depend)
 
+        # Then
         self.assertMultiLineEqual(depend.to_string(), r_depend)
+        self.assertEqual(depend.packages,
+                         [Requirement.from_spec_string("Qt 4.8.5")])
 
     def test_from_string_no_python_tag_no_default(self):
         # Given
@@ -386,6 +392,7 @@ packages = []
 
         # Then
         self.assertMultiLineEqual(depend.to_string(), r_depend)
+        self.assertEqual(depend.packages, [])
 
     def test_windows_platform(self):
         r_depend = """\
@@ -908,6 +915,7 @@ class TestEggInfo(unittest.TestCase):
         # Then
         self.assertEqual(metadata.name, "enstaller")
         self.assertEqual(metadata.metadata_version_info, (1, 1))
+        self.assertEqual(metadata.runtime_dependencies, tuple())
 
     def test_from_cross_platform_egg(self):
         # Given
@@ -929,6 +937,25 @@ class TestEggInfo(unittest.TestCase):
     def test_from_platform_egg(self):
         # Given
         egg = ETS_EGG
+        r_runtime_dependencies = (
+            Requirement.from_spec_string('apptools 4.2.0-2'),
+            Requirement.from_spec_string('blockcanvas 4.0.3-1'),
+            Requirement.from_spec_string('casuarius 1.1-1'),
+            Requirement.from_spec_string('chaco 4.3.0-2'),
+            Requirement.from_spec_string('codetools 4.1.0-2'),
+            Requirement.from_spec_string('enable 4.3.0-5'),
+            Requirement.from_spec_string('enaml 0.6.8-2'),
+            Requirement.from_spec_string('encore 0.3-1'),
+            Requirement.from_spec_string('envisage 4.3.0-2'),
+            Requirement.from_spec_string('etsdevtools 4.0.2-1'),
+            Requirement.from_spec_string('etsproxy 0.1.2-1'),
+            Requirement.from_spec_string('graphcanvas 4.0.2-1'),
+            Requirement.from_spec_string('mayavi 4.3.0-3'),
+            Requirement.from_spec_string('pyface 4.3.0-2'),
+            Requirement.from_spec_string('scimath 4.1.2-2'),
+            Requirement.from_spec_string('traits 4.3.0-2'),
+            Requirement.from_spec_string('traitsui 4.3.0-2'),
+        )
 
         # When
         metadata = EggMetadata.from_egg(egg)
@@ -947,6 +974,7 @@ class TestEggInfo(unittest.TestCase):
         self.assertEqual(
             metadata.platform, EPDPlatform.from_epd_string("rh5-32")
         )
+        self.assertEqual(metadata.runtime_dependencies, r_runtime_dependencies)
 
     def test_to_spec_string(self):
         # Given

--- a/okonomiyaki/repositories/enpkg.py
+++ b/okonomiyaki/repositories/enpkg.py
@@ -60,7 +60,7 @@ class EnpkgS3IndexEntry(HasTraits):
         kw["build"] = metadata.build
         kw["python"] = metadata._python
         kw["type"] = "egg"
-        kw["packages"] = metadata.runtime_dependencies
+        kw["packages"] = list(metadata.runtime_dependencies)
         kw["product"] = product
         kw["egg_basename"] = metadata.egg_basename
 
@@ -74,7 +74,7 @@ class EnpkgS3IndexEntry(HasTraits):
         # Opening the same file can cause some IO errors, even on Linux (seen
         # when eggs were on a Samba share).
         kw["md5"] = compute_md5(path)
-        return cls.from_data(kw)
+        return cls(**kw)
 
     @classmethod
     def from_setuptools_egg(cls, path, build=1, product=_PRODUCT_DEFAULT,

--- a/okonomiyaki/repositories/enpkg.py
+++ b/okonomiyaki/repositories/enpkg.py
@@ -6,7 +6,7 @@ from ..bundled.traitlets import (
     HasTraits, Bool, Enum, Float, Instance, List, Long, Unicode
 )
 from ..file_formats import EggMetadata, egg_name
-from ..file_formats._egg_info import Dependency
+from ..file_formats._egg_info import Requirement
 from ..file_formats.setuptools_egg import parse_filename
 from ..utils import compute_md5
 from ..utils.traitlets import NoneOrUnicode
@@ -30,7 +30,7 @@ class EnpkgS3IndexEntry(HasTraits):
     md5 = Unicode()
     mtime = Float()
     egg_basename = Unicode()
-    packages = List(Instance(Dependency))
+    packages = List(Instance(Requirement))
     product = Enum(["pypi", "commercial", "free"], _PRODUCT_DEFAULT)
     python = NoneOrUnicode()
     size = Long()
@@ -46,7 +46,7 @@ class EnpkgS3IndexEntry(HasTraits):
         Note: the passed in dictionary may be modified.
         """
         data["packages"] = [
-            Dependency.from_spec_string(s) for s in data.get("packages", [])
+            Requirement.from_spec_string(s) for s in data.get("packages", [])
         ]
         return cls(**data)
 


### PR DESCRIPTION
* rename `Dependency` to the better `Requirement`
* use `Requirement` in `EggMetadata` instead of strings.

@sjagoe 