### PR TITLE
ENH: add EPDPlatform.from_running_python.

### DIFF
--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -67,6 +67,14 @@ class EPDPlatform(HasTraits):
     """
 
     @classmethod
+    def from_running_python(cls):
+        """
+        Attempt to create an EPDPlatform instance by guessing the running
+        python. May raise an OkonomiyakiError exception
+        """
+        return cls(Platform.from_running_python())
+
+    @classmethod
     def from_running_system(cls, arch_name=None):
         """
         Attempt to create an EPDPlatform instance by guessing the running

--- a/okonomiyaki/platforms/tests/test_epd_platform.py
+++ b/okonomiyaki/platforms/tests/test_epd_platform.py
@@ -30,6 +30,40 @@ class TestEPDPlatform(unittest.TestCase):
         for epd_platform_string in EPD_PLATFORM_SHORT_NAMES:
             EPDPlatform.from_epd_string(epd_platform_string)
 
+    @mock_darwin
+    @mock_machine_x86_64
+    def test_from_running_python(self):
+        # When
+        with mock_architecture_32bit:
+            platform = EPDPlatform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.short, "osx-32")
+
+        # When
+        with mock_architecture_64bit:
+            platform = EPDPlatform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.short, "osx-64")
+
+    @mock_darwin
+    @mock_machine_x86_64
+    def test_from_running_system(self):
+        # When
+        with mock_architecture_32bit:
+            platform = EPDPlatform.from_running_system()
+
+        # Then
+        self.assertEqual(platform.short, "osx-64")
+
+        # When
+        with mock_architecture_64bit:
+            platform = EPDPlatform.from_running_system()
+
+        # Then
+        self.assertEqual(platform.short, "osx-64")
+
     def test_epd_platform_from_string_new_arch(self):
         def old_to_new_name(epd_platform_string):
             left, right = epd_platform_string.split("-")


### PR DESCRIPTION
Add a `from_running_python` to `EPDPlatform`, using the architecture of the running python process to determine the architecture (e.g. 64 bits for 64 bits python even if the underlying machine/kernel is 32 bits)

@sjagoe 