### PR TITLE
Add major only python tag support

### DIFF
--- a/okonomiyaki/errors.py
+++ b/okonomiyaki/errors.py
@@ -17,10 +17,9 @@ class InvalidEggName(InvalidPackageFormat):
 
 
 class InvalidMetadata(InvalidPackageFormat):
-    def __init__(self, message, attribute, *a, **kw):
+    def __init__(self, message, *a, **kw):
         self.message = message
-        self.attribute = attribute
-        super(InvalidMetadata, self).__init__(message, attribute, *a, **kw)
+        super(InvalidMetadata, self).__init__(message, *a, **kw)
 
     def __str__(self):
         return self.message

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -103,7 +103,7 @@ def parse_rawspec(spec_string):
             res[key] = spec[key]
         except KeyError:
             msg = "Missing attribute {0!r} (metadata_version: {1!r})"
-            raise InvalidMetadata(msg.format(key, metadata_version), key)
+            raise InvalidMetadata(msg.format(key, metadata_version))
     return res
 
 
@@ -277,7 +277,7 @@ def _get_default_python_tag(python_tag, python):
         python_tag = _PYTHON_VERSION_TO_PYTHON_TAG.get(python, _UNSUPPORTED)
         if python_tag == _UNSUPPORTED:
             msg = "python_tag cannot be guessed for python = {0}"
-            raise InvalidMetadata(msg.format(python), _TAG_PYTHON_PEP425_TAG)
+            raise InvalidMetadata(msg.format(python))
 
     return python_tag
 

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -675,8 +675,8 @@ class EggMetadata(object):
             The 'raw' name, i.e. the name value in spec/depend.
         version: EnpkgVersion
             The full version
-        platform: Platform
-            An okonomyaki platform instance, or None for cross-platform eggs
+        platform: EPDPlatform
+            An EPDPlatform instance, or None for cross-platform eggs
         python_tag: str
             The python tag, e.g. 'cp27'. May be None.
         abi_tag: str

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -505,7 +505,7 @@ def _python_tag_to_python(python_tag):
         d = m.groupdict()
         version = d["version"]
         if len(version) == 1:
-            if version[0] == "2":
+            if version == "2":
                 return "2.7"
             else:
                 raise InvalidMetadata(generic_msg)

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -505,8 +505,10 @@ def _python_tag_to_python(python_tag):
         d = m.groupdict()
         version = d["version"]
         if len(version) == 1:
-            msg = "Version {0!r} not supported".format(version)
-            raise InvalidMetadata(msg)
+            if version[0] == "2":
+                return "2.7"
+            else:
+                raise InvalidMetadata(generic_msg)
         elif len(version) == 2:
             return "{0}.{1}".format(version[0], version[1])
         else:

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -918,6 +918,49 @@ packages = [
         with self.assertRaises(InvalidMetadata) as exc:
             parse_rawspec(spec_s)
 
+    def test_python_tag_major_version_only(self):
+        # Given
+        name = "numpy"
+        version = EnpkgVersion.from_string("1.9.2-1")
+        platform = EPDPlatform.from_epd_string("osx-64")
+        python_tag = "py2"
+        abi_tag = "cp27m"
+        dependencies = Dependencies()
+        pkg_info = None
+        summary = "a few words"
+
+        r_spec_depend_string = textwrap.dedent("""\
+        metadata_version = '1.3'
+        name = 'numpy'
+        version = '1.9.2'
+        build = 1
+
+        arch = 'amd64'
+        platform = 'darwin'
+        osdist = None
+        python = '2.7'
+
+        python_tag = 'py2'
+        abi_tag = 'cp27m'
+        platform_tag = 'macosx_10_6_x86_64'
+
+        packages = []
+        """)
+
+        # When
+        metadata = EggMetadata(name, version, platform, python_tag,
+            abi_tag, dependencies, pkg_info, summary
+        )
+
+        # Then
+        self.assertEqual(metadata._python, "2.7")
+        self.assertEqual(metadata.python_tag, "py2")
+        self.assertEqual(metadata.metadata_version_info, (1, 3))
+        self.assertMultiLineEqual(
+            metadata.spec_depend_string,
+            r_spec_depend_string,
+        )
+
 
 class TestEggInfo(unittest.TestCase):
     def test_simple(self):

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -367,7 +367,7 @@ packages = [
 """
 
         # When/Then
-        with self.assertRaises(InvalidMetadata) as exc:
+        with self.assertRaises(InvalidMetadata):
             LegacySpecDepend.from_string(r_depend)
 
     def test_to_string(self):
@@ -874,7 +874,7 @@ packages = [
 """
 
         # When/Then
-        with self.assertRaises(UnsupportedMetadata) as exc:
+        with self.assertRaises(UnsupportedMetadata):
             parse_rawspec(spec_s)
 
         # Given a spec_string without some other metadata in >= 1.1
@@ -894,7 +894,7 @@ packages = [
 """
 
         # When/Then
-        with self.assertRaises(InvalidMetadata) as exc:
+        with self.assertRaises(InvalidMetadata):
             parse_rawspec(spec_s)
 
         # Given a spec_string without some other metadata in >= 1.2
@@ -915,7 +915,7 @@ packages = [
 """
 
         # When/Then
-        with self.assertRaises(InvalidMetadata) as exc:
+        with self.assertRaises(InvalidMetadata):
             parse_rawspec(spec_s)
 
     def test_python_tag_major_version_only(self):
@@ -949,8 +949,7 @@ packages = [
 
         # When
         metadata = EggMetadata(name, version, platform, python_tag,
-            abi_tag, dependencies, pkg_info, summary
-        )
+                               abi_tag, dependencies, pkg_info, summary)
 
         # Then
         self.assertEqual(metadata._python, "2.7")

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -960,6 +960,11 @@ packages = [
             r_spec_depend_string,
         )
 
+        # When/Then
+        with self.assertRaises(InvalidMetadata):
+            EggMetadata(name, version, platform, "py3", abi_tag,
+                        dependencies, pkg_info, summary)
+
 
 class TestEggInfo(unittest.TestCase):
     def test_simple(self):

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -369,7 +369,6 @@ packages = [
         # When/Then
         with self.assertRaises(InvalidMetadata) as exc:
             LegacySpecDepend.from_string(r_depend)
-        self.assertEqual(exc.exception.attribute, "python_tag")
 
     def test_to_string(self):
         # Given
@@ -897,7 +896,6 @@ packages = [
         # When/Then
         with self.assertRaises(InvalidMetadata) as exc:
             parse_rawspec(spec_s)
-        self.assertEqual(exc.exception.attribute, "platform")
 
         # Given a spec_string without some other metadata in >= 1.2
         spec_s = """\
@@ -919,7 +917,6 @@ packages = [
         # When/Then
         with self.assertRaises(InvalidMetadata) as exc:
             parse_rawspec(spec_s)
-        self.assertEqual(exc.exception.attribute, "python_tag")
 
 
 class TestEggInfo(unittest.TestCase):


### PR DESCRIPTION
@sjagoe 

I decided against support `py3` as we may want to support `3.4` (brood) and `3.5` (now in beta) when supporting python 3. Hopefully at that point we will be in position to update to a new metadata format `2.0`. 