### PR TITLE
ENH: add abi tag guessing for SetuptoolsMetadata.from_egg.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+XXXX-XX-XX   0.9.0:
+-------------------
+
+Improvements:
+
+  * SetuptoolsEggMetadata now can guess ABI for legacy cases. (#74)
+
 2015-06-30   0.8.0:
 -------------------
 

--- a/okonomiyaki/file_formats/setuptools_egg.py
+++ b/okonomiyaki/file_formats/setuptools_egg.py
@@ -77,25 +77,16 @@ def _get_default_setuptools_abi(platform_string, pyver):
 _UNSPECIFIED = object()
 
 
-def _guess_abi_from_python_tag(python_tag):
+def _guess_abi_from_python(python):
     # For legacy (aka legacy spec version info < 1.3), we know that pyver
     # can only be one of "2.X" with X in (5, 6, 7).
     #
     # In those cases, the mapping (platform pyver) -> ABI is unambiguous,
     # as we only ever used one ABI for a given python version/platform.
-    pyver = _python_tag_to_python(python_tag)
-    return "cp{0}{1}m".format(pyver[0], pyver[2])
+    return "cp{0}{1}m".format(python.major, python.minor)
 
 
-def _guess_abi(platform, python_tag):
-    if platform is None:
-        return None
-
-    if python_tag is not None:
-        pyver = _python_tag_to_python(python_tag)
-        if pyver != "{0}.{1}".format(*sys.version_info[:2]):
-            return _guess_abi_from_python_tag(python_tag)
-
+def _guess_abi_from_running_python():
     if sysconfig is None:
         soabi = None
     else:
@@ -107,13 +98,29 @@ def _guess_abi(platform, python_tag):
 
     if soabi and soabi.startswith('cpython-'):
         return 'cp' + soabi.split('-', 1)[-1]
-    elif python_tag is not None:
-        return _guess_abi_from_python_tag(python_tag)
     else:
-        msg = ("Could not guess ABI, you need to specify the abi_tag "
-               "argument to from_egg, e.g. 'cp34m' for Enthought "
-               "CPython 3.4 runtimes")
-        raise OkonomiyakiError(msg)
+        return None
+
+
+def _guess_abi(platform, python):
+    if platform is None:
+        return None
+
+    if python is not None:
+        if (python.major, python.minor) != sys.version_info[:2]:
+            return _guess_abi_from_python(python)
+
+    abi = _guess_abi_from_running_python()
+    if abi is None:
+        if python is not None:
+            return _guess_abi_from_python(python)
+        else:
+            msg = ("Could not guess ABI, you need to specify the abi_tag "
+                   "argument to from_egg, e.g. 'cp34m' for Enthought "
+                   "CPython 3.4 runtimes")
+            raise OkonomiyakiError(msg)
+    else:
+        return abi
 
 
 class SetuptoolsEggMetadata(object):
@@ -132,7 +139,7 @@ class SetuptoolsEggMetadata(object):
             python = PythonImplementation.from_string(_guess_python_tag(pyver))
 
         if abi_tag is _UNSPECIFIED:
-            abi_tag = _guess_abi(platform, python_tag)
+            abi_tag = _guess_abi(platform, python)
         else:
             abi_tag = abi_tag
 

--- a/okonomiyaki/file_formats/setuptools_egg.py
+++ b/okonomiyaki/file_formats/setuptools_egg.py
@@ -39,7 +39,7 @@ def parse_filename(path):
     platform : str or None
         the platform string, or None for platform-independent eggs.
     """
-    m = _R_EGG_NAME.search(path)
+    m = _R_EGG_NAME.search(os.path.basename(path))
     if m:
         platform = m.group("platform")
         return (m.group("name"), m.group("version"), m.group("pyver"),

--- a/okonomiyaki/file_formats/setuptools_egg.py
+++ b/okonomiyaki/file_formats/setuptools_egg.py
@@ -1,5 +1,6 @@
 import os.path
 import re
+import sys
 try:
     import sysconfig
 except ImportError:  # Python 2.6 support
@@ -7,7 +8,7 @@ except ImportError:  # Python 2.6 support
 import warnings
 
 from ..errors import OkonomiyakiError
-from ._egg_info import _guess_python_tag
+from ._egg_info import _guess_python_tag, _python_tag_to_python
 from ._package_info import PackageInfo
 
 
@@ -73,9 +74,28 @@ def _get_default_setuptools_abi(platform_string, pyver):
 _UNSPECIFIED = object()
 
 
-def _guess_abi(platform):
+def _guess_abi_from_python_tag(python_tag):
+    # For legacy (aka legacy spec version info < 1.3), we know that pyver
+    # can only be one of "2.X" with X in (5, 6, 7).
+    #
+    # In those cases, the mapping (platform pyver) -> ABI is unambiguous,
+    # as we only ever used one ABI for a given python version/platform.
+    pyver = _python_tag_to_python(python_tag)
+    return "cp{0}{1}m".format(pyver[0], pyver[2])
+
+
+def _guess_abi(platform, python_tag):
+    msg = ("Could not guess ABI, you need to specify the abi_tag "
+           "argument to from_egg, e.g. 'cp34m' for Enthought "
+           "CPython 3.4 runtimes")
+
     if platform is None:
         return None
+
+    if python_tag is not None:
+        pyver = _python_tag_to_python(python_tag)
+        if pyver != "{0}.{1}".format(*sys.version_info[:2]):
+            return _guess_abi_from_python_tag(python_tag)
 
     if sysconfig is None:
         soabi = None
@@ -88,6 +108,8 @@ def _guess_abi(platform):
 
     if soabi and soabi.startswith('cpython-'):
         return 'cp' + soabi.split('-', 1)[-1]
+    elif python_tag is not None:
+        return _guess_abi_from_python_tag(python_tag)
     else:
         msg = ("Could not guess ABI, you need to specify the abi_tag "
                "argument to from_egg, e.g. 'cp34m' for Enthought "
@@ -111,7 +133,7 @@ class SetuptoolsEggMetadata(object):
             python_tag = _guess_python_tag(pyver)
 
         if abi_tag is _UNSPECIFIED:
-            abi_tag = _guess_abi(platform)
+            abi_tag = _guess_abi(platform, python_tag)
         else:
             abi_tag = abi_tag
 

--- a/okonomiyaki/file_formats/setuptools_egg.py
+++ b/okonomiyaki/file_formats/setuptools_egg.py
@@ -85,10 +85,6 @@ def _guess_abi_from_python_tag(python_tag):
 
 
 def _guess_abi(platform, python_tag):
-    msg = ("Could not guess ABI, you need to specify the abi_tag "
-           "argument to from_egg, e.g. 'cp34m' for Enthought "
-           "CPython 3.4 runtimes")
-
     if platform is None:
         return None
 

--- a/okonomiyaki/file_formats/tests/test_setuptools_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_setuptools_file_format.py
@@ -108,10 +108,7 @@ class TestSetuptoolsEggMetadata(unittest.TestCase):
 
         # When
         platform = EPDPlatform.from_epd_string("osx-64")
-        abi_tag = "cp27m"
-        metadata = SetuptoolsEggMetadata.from_egg(
-            path, platform, abi_tag=abi_tag
-        )
+        metadata = SetuptoolsEggMetadata.from_egg(path, platform)
 
         # Then
         self.assertEqual(metadata.name, "traits")


### PR DESCRIPTION
This is the first step to fix ABI tag handling in enstaller `repack`: adds abi tag guessing for common cases and legacy cases.

@sjagoe 