### PR TITLE
Unstringify python tag

### DIFF
--- a/okonomiyaki/file_formats/__init__.py
+++ b/okonomiyaki/file_formats/__init__.py
@@ -11,3 +11,4 @@ from ._egg_info import (
 )
 from ._package_info import PackageInfo
 from .egg import EggBuilder, EggRewriter
+from .pep425 import PythonImplementation

--- a/okonomiyaki/file_formats/pep425.py
+++ b/okonomiyaki/file_formats/pep425.py
@@ -1,0 +1,57 @@
+import re
+
+from ..errors import InvalidMetadata
+
+
+_KIND_TO_ABBREVIATED = {
+    "cpython": "cp",
+    "python": "py",
+    "pypy": "pp",
+}
+
+_ABBREVIATED_TO_KIND = dict((v, k) for k, v in _KIND_TO_ABBREVIATED.items())
+
+_TAG_RE = re.compile("""
+    (?P<interpreter>([^\d]+))
+    (?P<version>([\d_]+))
+""", flags=re.VERBOSE)
+
+
+class PythonImplementation(object):
+    @classmethod
+    def from_string(cls, s):
+        m = _TAG_RE.match(s)
+        if m is None:
+            msg = "Invalid python tag string: {!r}".format(s)
+            raise InvalidMetadata(msg)
+        else:
+            d = m.groupdict()
+            kind = d["interpreter"]
+            version = d["version"]
+            if len(version) < 2:
+                msg = "Compressed python cannot be converted"
+                raise InvalidMetadata(msg)
+            elif len(version) > 2:
+                msg = "Python tag {0!r} not understood"
+                raise InvalidMetadata(msg.format(version))
+            else:
+                major = int(version[0])
+                minor = int(version[1])
+                return cls(kind, major, minor)
+
+    def __init__(self, kind, major, minor):
+        self.kind = _ABBREVIATED_TO_KIND.get(kind, kind)
+        self.major = major
+        self.minor = minor
+
+    @property
+    def abbreviated_implementation(self):
+        return _KIND_TO_ABBREVIATED.get(self.kind, self.kind)
+
+    @property
+    def pep425_tag(self):
+        """ PEP425-compliant python tag string. """
+        return str(self)
+
+    def __str__(self):
+        return "{0.abbreviated_implementation}{0.major}{0.minor}".format(self)

--- a/okonomiyaki/file_formats/setuptools_egg.py
+++ b/okonomiyaki/file_formats/setuptools_egg.py
@@ -6,9 +6,12 @@ except ImportError:  # Python 2.6 support
     sysconfig = None
 import warnings
 
+import six
+
 from ..errors import OkonomiyakiError
 from ._egg_info import _guess_python_tag
 from ._package_info import PackageInfo
+from .pep425 import PythonImplementation
 
 
 _R_EGG_NAME = re.compile("""
@@ -97,7 +100,7 @@ def _guess_abi(platform):
 
 class SetuptoolsEggMetadata(object):
     @classmethod
-    def from_egg(cls, path, platform=None, python_tag=_UNSPECIFIED,
+    def from_egg(cls, path, platform=None, python=_UNSPECIFIED,
                  abi_tag=_UNSPECIFIED):
         filename = os.path.basename(path)
         name, version, pyver, platform_string = parse_filename(filename)
@@ -107,8 +110,8 @@ class SetuptoolsEggMetadata(object):
                    "platform argument that is not None to from_egg")
             raise OkonomiyakiError(msg)
 
-        if python_tag is _UNSPECIFIED:
-            python_tag = _guess_python_tag(pyver)
+        if python is _UNSPECIFIED:
+            python = PythonImplementation.from_string(_guess_python_tag(pyver))
 
         if abi_tag is _UNSPECIFIED:
             abi_tag = _guess_abi(platform)
@@ -117,9 +120,9 @@ class SetuptoolsEggMetadata(object):
 
         pkg_info = PackageInfo.from_egg(path)
 
-        return cls(name, version, platform, python_tag, abi_tag, pkg_info)
+        return cls(name, version, platform, python, abi_tag, pkg_info)
 
-    def __init__(self, name, version, platform, python_tag, abi_tag, pkg_info):
+    def __init__(self, name, version, platform, python, abi_tag, pkg_info):
         """
         Parameters
         ----------
@@ -129,7 +132,7 @@ class SetuptoolsEggMetadata(object):
             Version string
         platform: EPDPlatform
             An EPDPlatform instance, or None for cross-platform eggs
-        python_tag: str
+        python: PythonImplementation
             The PEP425 python tag, or None.
         abi_tag: str
             The PEP425 abi tag, or None.
@@ -140,7 +143,9 @@ class SetuptoolsEggMetadata(object):
         self.version = version
 
         self.platform = platform
-        self.python_tag = python_tag
+        if isinstance(python, six.string_types):
+            python = PythonImplementation.from_string(python)
+        self.python = python
         self.abi_tag = abi_tag
 
         self._pkg_info = pkg_info
@@ -153,6 +158,13 @@ class SetuptoolsEggMetadata(object):
             return None
         else:
             return self.platform.pep425_tag
+
+    @property
+    def python_tag(self):
+        if self.python is None:
+            return None
+        else:
+            return self.python.pep425_tag
 
     @property
     def summary(self):

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -15,7 +15,7 @@ from ...platforms.legacy import LegacyEPDPlatform
 from ...versions import EnpkgVersion
 
 from .._egg_info import (
-    Requirement, Dependencies, EggMetadata, LegacySpecDepend, parse_rawspec,
+    Requirement, EggMetadata, LegacySpecDepend, parse_rawspec,
     split_egg_name
 )
 
@@ -678,53 +678,6 @@ packages = [
         # When/Then
         with self.assertRaises(InvalidMetadata):
             parse_rawspec(spec_s)
-
-    def test_python_tag_major_version_only(self):
-        # Given
-        name = "numpy"
-        version = EnpkgVersion.from_string("1.9.2-1")
-        platform = EPDPlatform.from_epd_string("osx-64")
-        python_tag = "py2"
-        abi_tag = "cp27m"
-        dependencies = Dependencies()
-        pkg_info = None
-        summary = "a few words"
-
-        r_spec_depend_string = textwrap.dedent("""\
-        metadata_version = '1.3'
-        name = 'numpy'
-        version = '1.9.2'
-        build = 1
-
-        arch = 'amd64'
-        platform = 'darwin'
-        osdist = None
-        python = '2.7'
-
-        python_tag = 'py2'
-        abi_tag = 'cp27m'
-        platform_tag = 'macosx_10_6_x86_64'
-
-        packages = []
-        """)
-
-        # When
-        metadata = EggMetadata(name, version, platform, python_tag,
-                               abi_tag, dependencies, pkg_info, summary)
-
-        # Then
-        self.assertEqual(metadata._python, "2.7")
-        self.assertEqual(metadata.python_tag, "py2")
-        self.assertEqual(metadata.metadata_version_info, (1, 3))
-        self.assertMultiLineEqual(
-            metadata.spec_depend_string,
-            r_spec_depend_string,
-        )
-
-        # When/Then
-        with self.assertRaises(InvalidMetadata):
-            EggMetadata(name, version, platform, "py3", abi_tag,
-                        dependencies, pkg_info, summary)
 
 
 class TestEggInfo(unittest.TestCase):

--- a/okonomiyaki/file_formats/tests/test_pep425.py
+++ b/okonomiyaki/file_formats/tests/test_pep425.py
@@ -1,0 +1,68 @@
+import unittest
+
+from ..pep425 import PythonImplementation
+from ...errors import InvalidMetadata
+
+
+class TestPythonImplementation(unittest.TestCase):
+    def test_simple(self):
+        # Given
+        kind = "cpython"
+        major = 2
+        minor = 7
+
+        # When
+        tag = PythonImplementation(kind, major, minor)
+
+        # Then
+        self.assertEqual(tag.abbreviated_implementation, "cp")
+        self.assertEqual(str(tag), "cp27")
+
+    def test_abbreviations(self):
+        # Given
+        kinds = (("cpython", "cp"), ("python", "py"), ("pypy", "pp"),
+                 ("dummy", "dummy"))
+        major = 2
+        minor = 7
+
+        # When/Then
+        for kind, r_abbreviated in kinds:
+            tag = PythonImplementation(kind, major, minor)
+            self.assertEqual(tag.abbreviated_implementation, r_abbreviated)
+
+    def test_from_string(self):
+        # Given
+        tag_string = "cp27"
+
+        # When
+        tag = PythonImplementation.from_string(tag_string)
+
+        # Then
+        self.assertEqual(tag.kind, "cpython")
+        self.assertEqual(tag.major, 2)
+        self.assertEqual(tag.minor, 7)
+
+        # Given
+        tag_string = "python34"
+
+        # When
+        tag = PythonImplementation.from_string(tag_string)
+
+        # Then
+        self.assertEqual(tag.kind, "python")
+        self.assertEqual(tag.major, 3)
+        self.assertEqual(tag.minor, 4)
+
+        # Given
+        tag_string = "py3"
+
+        # When/Then
+        with self.assertRaises(InvalidMetadata):
+            PythonImplementation.from_string(tag_string)
+
+        # Given
+        tag_string = "py345"
+
+        # When/Then
+        with self.assertRaises(InvalidMetadata):
+            PythonImplementation.from_string(tag_string)


### PR DESCRIPTION
Use a proper object `PythonImplementation` to represent python tags instead of strings.

Backward compatibility is almost kept by automatically converting string to `PythonImplementation` instances in `EggMetadata` constructor (I changed the argument name to `EggMetadata.__init__` from `python_tag` to `python` for consistency's sake though).

@sjagoe