### PR TITLE
ENH: automatically convert arch string in EPDPlatform.from_epd_string.

### DIFF
--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -96,6 +96,9 @@ class EPDPlatform(HasTraits):
     def from_epd_string(cls, s):
         """
         Create a new instance from an epd platform string (e.g. 'win-32')
+
+        Note: new, more explicit architecture names are also supported, e.g.
+        'win-x86' or 'win-x86_64' are supported.
         """
         parts = s.split("-")
         if len(parts) != 2:
@@ -103,16 +106,13 @@ class EPDPlatform(HasTraits):
 
         platform_name, arch_bits = parts
         if arch_bits not in _ARCHBITS_TO_ARCH:
-            msg = ("Invalid epd string {0!r}: invalid arch {1!r}".
-                   format(s, arch_bits))
-            raise OkonomiyakiError(msg)
+            arch = machine = Arch(arch_bits)
         else:
             arch_name = _ARCHBITS_TO_ARCH[arch_bits]
-
             arch = machine = Arch(arch_name)
-            os, name, family, release = _epd_name_to_quadruplet(platform_name)
-            platform = Platform(os, name, family, arch, machine, release)
-            return cls(platform)
+        os, name, family, release = _epd_name_to_quadruplet(platform_name)
+        platform = Platform(os, name, family, arch, machine, release)
+        return cls(platform)
 
     @classmethod
     def _from_spec_depend_data(cls, platform, osdist, arch_name):

--- a/okonomiyaki/platforms/tests/test_epd_platform.py
+++ b/okonomiyaki/platforms/tests/test_epd_platform.py
@@ -30,6 +30,34 @@ class TestEPDPlatform(unittest.TestCase):
         for epd_platform_string in EPD_PLATFORM_SHORT_NAMES:
             EPDPlatform.from_epd_string(epd_platform_string)
 
+    def test_epd_platform_from_string_new_names(self):
+        """Ensure every epd short platform is understood by EPDPlatform."""
+        # Given
+        archs = ("i386", "x86", "i686")
+
+        # When
+        epd_platforms = tuple(
+            EPDPlatform.from_epd_string("rh5-" + arch)
+            for arch in archs
+        )
+
+        # Then
+        for epd_platform in epd_platforms:
+            self.assertEqual(epd_platform.arch_bits, "32")
+
+        # Given
+        archs = ("amd64", "x86_64", "AMD64")
+
+        # When
+        epd_platforms = tuple(
+            EPDPlatform.from_epd_string("rh5-" + arch)
+            for arch in archs
+        )
+
+        # Then
+        for epd_platform in epd_platforms:
+            self.assertEqual(epd_platform.arch_bits, "64")
+
     @mock_darwin
     @mock_machine_x86_64
     def test_from_running_python(self):


### PR DESCRIPTION
Add support for epd string like `rh5-amd64` or `rh5-x86_64`.

@sjagoe 