### PR TITLE
Avoid sha256 calculation blacklist

### DIFF
--- a/okonomiyaki/file_formats/_blacklist/__init__.py
+++ b/okonomiyaki/file_formats/_blacklist/__init__.py
@@ -32,7 +32,7 @@ _EGG_PLATFORM_BLACK_LIST = {
         "7b89c3b6d2878ff3be36131525a9bb616c4f54c6d71d9125cd3612a6fd403c9f":
             "win-32",
     },
-    "_registry_path-1.0.0-1.egg": {
+    "_registry_path-1.0-1.egg": {
         "9f040cbe901c0f827e5993a8476e768c40a399d69edde567610d59a3848530aa":
             "win-64",
         "21e03dd728f91b4bd59ad80e73ada7d5c5cea6acf2a7f7e3d25a92ba9992f07c":

--- a/okonomiyaki/file_formats/_blacklist/__init__.py
+++ b/okonomiyaki/file_formats/_blacklist/__init__.py
@@ -66,16 +66,11 @@ _EGG_PLATFORM_BLACK_LIST = {
 
 
 # (egg sha256) -> (epd platform string) mapping
-def _compute_egg_platform_black_list():
-    ret = {}
-    for egg in _EGG_PLATFORM_BLACK_LIST.values():
-        for checksum, platform_string in egg.items():
-            ret[checksum] = platform_string
-    return ret
-
-
-EGG_PLATFORM_BLACK_LIST = _compute_egg_platform_black_list()
-del _compute_egg_platform_black_list
+EGG_PLATFORM_BLACK_LIST = dict(
+    (checksum, platform_string)
+    for egg in _EGG_PLATFORM_BLACK_LIST.values()
+    for checksum, platform_string in egg.items()
+)
 
 
 def may_be_in_platform_blacklist(path):

--- a/okonomiyaki/file_formats/_blacklist/__init__.py
+++ b/okonomiyaki/file_formats/_blacklist/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
-from .pkg_info_data import EGG_PKG_INFO_BLACK_LIST
+from .pkg_info_data import (
+    EGG_PKG_INFO_BLACK_LIST, may_be_in_pkg_info_blacklist
+)
 
 
 _EGG_PLATFORM_BLACK_LIST = {
@@ -73,7 +75,8 @@ def _compute_egg_platform_black_list():
 EGG_PLATFORM_BLACK_LIST = _compute_egg_platform_black_list()
 del _compute_egg_platform_black_list
 
+
 __all__ = [
-    "CONTENT_SPEC_DEPEND_PLATFORM_BLACK_LIST",
-    "EGG_PKG_INFO_BLACK_LIST"
+    "CONTENT_SPEC_DEPEND_PLATFORM_BLACK_LIST", "EGG_PKG_INFO_BLACK_LIST",
+    "may_be_in_pkg_info_blacklist",
 ]

--- a/okonomiyaki/file_formats/_blacklist/__init__.py
+++ b/okonomiyaki/file_formats/_blacklist/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import os.path
+
 from .pkg_info_data import (
     EGG_PKG_INFO_BLACK_LIST, may_be_in_pkg_info_blacklist
 )
@@ -74,6 +76,12 @@ def _compute_egg_platform_black_list():
 
 EGG_PLATFORM_BLACK_LIST = _compute_egg_platform_black_list()
 del _compute_egg_platform_black_list
+
+
+def may_be_in_platform_blacklist(path):
+    """ Returns True if the given egg path may be in the PKG INFO blacklist.
+    """
+    return os.path.basename(path) in _EGG_PLATFORM_BLACK_LIST
 
 
 __all__ = [

--- a/okonomiyaki/file_formats/_blacklist/__init__.py
+++ b/okonomiyaki/file_formats/_blacklist/__init__.py
@@ -32,7 +32,7 @@ _EGG_PLATFORM_BLACK_LIST = {
         "7b89c3b6d2878ff3be36131525a9bb616c4f54c6d71d9125cd3612a6fd403c9f":
             "win-32",
     },
-    "_registry_path-1.0-1.egg": {
+    "_registry_path-1.0-2.egg": {
         "9f040cbe901c0f827e5993a8476e768c40a399d69edde567610d59a3848530aa":
             "win-64",
         "21e03dd728f91b4bd59ad80e73ada7d5c5cea6acf2a7f7e3d25a92ba9992f07c":

--- a/okonomiyaki/file_formats/_blacklist/pkg_info_data.py
+++ b/okonomiyaki/file_formats/_blacklist/pkg_info_data.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+import os.path
+
 
 PYSIDE_1_0_7_PKG_INFO = u"""\
 Metadata-Version: 1.0
@@ -796,13 +798,33 @@ Classifier: Topic :: Software Development :: Widget Sets
 
 
 # egg's sha256 to correcty decoded PKG_INFO content
-EGG_PKG_INFO_BLACK_LIST = {
-    "ca0903cc398aa69da1939be22bac52941ac2d8dd0a197eb2c449fdddd6339f80":
-        PYSIDE_1_0_7_PKG_INFO,
-    "79174bb334fddb06a970e8e61f78c94d90259ca10dd85f88516c02bf4f135f45":
-        PYSIDE_1_0_8_PKG_INFO,
-    "8d880887fb8155329888decdd8fc1fdbce1a214da9a98206a64f0ee57b554279":
-        PYSIDE_1_0_9_PKG_INFO,
-    "5eff70cfb464c2d531e6f93f7601e8ef8255b3a1ab4dd533826cfdcd5b962b60":
-        PYSIDE_1_1_0_PKG_INFO,
+_EGG_PKG_INFO_BLACK_LIST = {
+    "PySide-1.0.7-1.egg": {
+        "ca0903cc398aa69da1939be22bac52941ac2d8dd0a197eb2c449fdddd6339f80":
+            PYSIDE_1_0_7_PKG_INFO,
+    },
+    "PySide-1.0.8-1.egg": {
+        "79174bb334fddb06a970e8e61f78c94d90259ca10dd85f88516c02bf4f135f45":
+            PYSIDE_1_0_8_PKG_INFO,
+    },
+    "PySide-1.0.8-1.egg": {
+        "8d880887fb8155329888decdd8fc1fdbce1a214da9a98206a64f0ee57b554279":
+            PYSIDE_1_0_9_PKG_INFO,
+    },
+    "PySide-1.1.0-3.egg": {
+        "5eff70cfb464c2d531e6f93f7601e8ef8255b3a1ab4dd533826cfdcd5b962b60":
+            PYSIDE_1_1_0_PKG_INFO,
+    }
 }
+
+EGG_PKG_INFO_BLACK_LIST = {
+    checksum: pkg_info_data
+    for egg in _EGG_PKG_INFO_BLACK_LIST.values()
+    for checksum, pkg_info_data in egg.items()
+}
+
+
+def may_be_in_pkg_info_blacklist(path):
+    """ Returns True if the given egg path may be in the PKG INFO blacklist.
+    """
+    return os.path.basename(path) in _EGG_PKG_INFO_BLACK_LIST

--- a/okonomiyaki/file_formats/_blacklist/pkg_info_data.py
+++ b/okonomiyaki/file_formats/_blacklist/pkg_info_data.py
@@ -802,17 +802,27 @@ _EGG_PKG_INFO_BLACK_LIST = {
     "PySide-1.0.7-1.egg": {
         "ca0903cc398aa69da1939be22bac52941ac2d8dd0a197eb2c449fdddd6339f80":
             PYSIDE_1_0_7_PKG_INFO,
+        "946211c1f20f01bb5a29ec8783acd74a5ed234b3ced88a5256861077b2f1c34d":
+            PYSIDE_1_0_7_PKG_INFO,
     },
     "PySide-1.0.8-1.egg": {
         "79174bb334fddb06a970e8e61f78c94d90259ca10dd85f88516c02bf4f135f45":
             PYSIDE_1_0_8_PKG_INFO,
     },
-    "PySide-1.0.8-1.egg": {
+    "PySide-1.0.9-1.egg": {
         "8d880887fb8155329888decdd8fc1fdbce1a214da9a98206a64f0ee57b554279":
             PYSIDE_1_0_9_PKG_INFO,
+        "8d1ff3f8713c84cc8aa36cbac49051b094ecb2863b8dfa1b5ccd737ae82c14a8":
+            PYSIDE_1_0_9_PKG_INFO,
+    },
+    "PySide-1.1.0-2.egg": {
+        "c0a73ef8843e0934287e57d0812b2b9024587bb034f6146ce0999207366edc4d":
+            PYSIDE_1_1_0_PKG_INFO,
     },
     "PySide-1.1.0-3.egg": {
         "5eff70cfb464c2d531e6f93f7601e8ef8255b3a1ab4dd533826cfdcd5b962b60":
+            PYSIDE_1_1_0_PKG_INFO,
+        "afb7402aa38ccef4ed5d0233807bb6611b59e24106fc27f6d271b11cf9562454":
             PYSIDE_1_1_0_PKG_INFO,
     }
 }

--- a/okonomiyaki/file_formats/_blacklist/pkg_info_data.py
+++ b/okonomiyaki/file_formats/_blacklist/pkg_info_data.py
@@ -817,11 +817,11 @@ _EGG_PKG_INFO_BLACK_LIST = {
     }
 }
 
-EGG_PKG_INFO_BLACK_LIST = {
-    checksum: pkg_info_data
+EGG_PKG_INFO_BLACK_LIST = dict(
+    (checksum, pkg_info_data)
     for egg in _EGG_PKG_INFO_BLACK_LIST.values()
     for checksum, pkg_info_data in egg.items()
-}
+)
 
 
 def may_be_in_pkg_info_blacklist(path):

--- a/okonomiyaki/file_formats/_blacklist/pkg_info_data.py
+++ b/okonomiyaki/file_formats/_blacklist/pkg_info_data.py
@@ -809,6 +809,10 @@ _EGG_PKG_INFO_BLACK_LIST = {
         "79174bb334fddb06a970e8e61f78c94d90259ca10dd85f88516c02bf4f135f45":
             PYSIDE_1_0_8_PKG_INFO,
     },
+    "PySide-1.0.8-2.egg": {
+        "79174bb334fddb06a970e8e61f78c94d90259ca10dd85f88516c02bf4f135f45":
+            PYSIDE_1_0_8_PKG_INFO,
+    },
     "PySide-1.0.9-1.egg": {
         "8d880887fb8155329888decdd8fc1fdbce1a214da9a98206a64f0ee57b554279":
             PYSIDE_1_0_9_PKG_INFO,
@@ -816,6 +820,8 @@ _EGG_PKG_INFO_BLACK_LIST = {
             PYSIDE_1_0_9_PKG_INFO,
     },
     "PySide-1.1.0-2.egg": {
+        "16644aaaa1d2447677634d6dfe8fc5f9890be731641c4f46448646d1c409c656":
+            PYSIDE_1_1_0_PKG_INFO,
         "c0a73ef8843e0934287e57d0812b2b9024587bb034f6146ce0999207366edc4d":
             PYSIDE_1_1_0_PKG_INFO,
     },

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -653,7 +653,7 @@ class EggMetadata(object):
         if pkg_info_data is None:
             pkg_info = None
         else:
-            pkg_info = PackageInfo.from_string(pkg_info_data)
+            pkg_info = PackageInfo.from_egg(path_or_file)
 
         return cls._from_spec_depend(spec_depend, pkg_info, summary)
 

--- a/okonomiyaki/file_formats/_package_info.py
+++ b/okonomiyaki/file_formats/_package_info.py
@@ -5,7 +5,6 @@ We support only 1.0 and 1.1, as 1.2 does not seem to be used anywhere ?
 """
 import contextlib
 
-import six
 import zipfile2
 
 from ..utils import py3compat, compute_sha256
@@ -91,7 +90,7 @@ class PackageInfo(object):
 
     @classmethod
     def from_string(cls, s):
-        if not isinstance(s, six.text_type):
+        if not isinstance(s, py3compat.text_type):
             raise ValueError("Expected text value, got {0!r}".format(type(s)))
         fp = py3compat.StringIO(s)
         msg = _parse(fp)

--- a/okonomiyaki/file_formats/_package_info.py
+++ b/okonomiyaki/file_formats/_package_info.py
@@ -5,6 +5,7 @@ We support only 1.0 and 1.1, as 1.2 does not seem to be used anywhere ?
 """
 import contextlib
 
+import six
 import zipfile2
 
 from ..utils import py3compat, compute_sha256
@@ -90,7 +91,9 @@ class PackageInfo(object):
 
     @classmethod
     def from_string(cls, s):
-        fp = py3compat.StringIO(_must_decode(s))
+        if not isinstance(s, six.text_type):
+            raise ValueError("Expected text value, got {0!r}".format(type(s)))
+        fp = py3compat.StringIO(s)
         msg = _parse(fp)
 
         kw = {}

--- a/okonomiyaki/file_formats/_package_info.py
+++ b/okonomiyaki/file_formats/_package_info.py
@@ -10,7 +10,7 @@ import zipfile2
 from ..utils import py3compat, compute_sha256
 from ..errors import OkonomiyakiError
 
-from ._blacklist import EGG_PKG_INFO_BLACK_LIST
+from ._blacklist import EGG_PKG_INFO_BLACK_LIST, may_be_in_pkg_info_blacklist
 
 
 _PKG_INFO_LOCATION = "EGG-INFO/PKG-INFO"
@@ -65,8 +65,18 @@ class PackageInfo(object):
             If a string, understood as the path to the egg. Otherwise,
             understood as a zipfile-like object.
         """
+        sha256 = None
         if isinstance(path_or_file, py3compat.string_types):
-            sha256 = compute_sha256(path_or_file)
+            if may_be_in_pkg_info_blacklist(path_or_file):
+                sha256 = compute_sha256(path_or_file)
+        else:
+            with _keep_position(path_or_file.fp):
+                sha256 = compute_sha256(path_or_file.fp)
+        return cls._from_egg(path_or_file, sha256)
+
+    @classmethod
+    def _from_egg(cls, path_or_file, sha256):
+        if isinstance(path_or_file, py3compat.string_types):
             with zipfile2.ZipFile(path_or_file) as fp:
                 data = _read_pkg_info(fp)
             if data is None:
@@ -74,8 +84,6 @@ class PackageInfo(object):
                 raise OkonomiyakiError(msg)
         else:
             data = path_or_file.read(_PKG_INFO_LOCATION)
-            with _keep_position(path_or_file.fp):
-                sha256 = compute_sha256(path_or_file.fp)
 
         data = _convert_if_needed(data, sha256)
         return cls.from_string(data)
@@ -241,6 +249,9 @@ def _collapse_leading_ws(header, txt):
 
 
 def _convert_if_needed(data, sha256):
+    """ sha256 may be None, in which case it is assumed no special handling
+    through black list is needed.
+    """
     decoded_data = EGG_PKG_INFO_BLACK_LIST.get(sha256)
     if decoded_data is None:
         return data.decode(PKG_INFO_ENCODING)

--- a/okonomiyaki/file_formats/tests/common.py
+++ b/okonomiyaki/file_formats/tests/common.py
@@ -27,7 +27,7 @@ with open(os.path.join(DATA_DIR, "pymongo_description.txt"), "rb") as fp:
     UNICODE_DESCRIPTION_TEXT = fp.read().decode("utf8")
 
 # flake8: noqa
-PKG_INFO_ENSTALLER_1_0 = """\
+PKG_INFO_ENSTALLER_1_0 = u"""\
 Metadata-Version: 1.0
 Name: enstaller
 Version: 4.5.0
@@ -164,7 +164,7 @@ Classifier: Topic :: System :: Software Distribution
 Classifier: Topic :: System :: Systems Administration
 """
 
-PKG_INFO_ENSTALLER_1_0_DESCRIPTION = """\
+PKG_INFO_ENSTALLER_1_0_DESCRIPTION = u"""\
 The Enstaller (version 4) project is a managing and install tool
 for egg-based Python distributions.
 
@@ -283,7 +283,7 @@ all EPD installers already include Enstaller.
 """
 
 # flake8: noqa
-PIP_PKG_INFO = """\
+PIP_PKG_INFO = u"""\
 Metadata-Version: 1.1
 Name: pip
 Version: 6.0.8

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -22,7 +22,8 @@ from .._egg_info import (
 )
 
 from .common import (
-    DATA_DIR, ENSTALLER_EGG, ETS_EGG, MKL_EGG, _OSX64APP_EGG, XZ_5_2_0_EGG
+    BROKEN_MCCABE_EGG, DATA_DIR, ENSTALLER_EGG, ETS_EGG, MKL_EGG,
+    _OSX64APP_EGG, XZ_5_2_0_EGG
 )
 
 
@@ -913,3 +914,15 @@ class TestEggInfo(unittest.TestCase):
 
         # Then
         self.assertEqual(metadata.platform_tag, "win32")
+
+        # Given
+        egg = BROKEN_MCCABE_EGG
+
+        # When
+        with mock.patch(
+            "okonomiyaki.file_formats._egg_info.compute_sha256",
+        ) as mocked_compute_sha256:
+            metadata = EggMetadata.from_egg(egg)
+
+        # Then
+        self.assertFalse(mocked_compute_sha256.called)

--- a/okonomiyaki/file_formats/tests/test__package_info.py
+++ b/okonomiyaki/file_formats/tests/test__package_info.py
@@ -56,7 +56,7 @@ class TestPackageInfo(unittest.TestCase):
 
     def test_from_string_unsupported(self):
         # Given
-        data = "Metadata-Version: 1.2"
+        data = u"Metadata-Version: 1.2"
 
         # When/Then
         with self.assertRaises(OkonomiyakiError):

--- a/okonomiyaki/file_formats/tests/test__package_info.py
+++ b/okonomiyaki/file_formats/tests/test__package_info.py
@@ -173,3 +173,16 @@ class TestPackageInfo(unittest.TestCase):
         self.assertMultiLineEqual(
             pkg_info.description, FAKE_PYSIDE_1_1_0_EGG_PKG_INFO
         )
+
+        # Given
+        # An egg not in the blacklist
+        egg = BROKEN_MCCABE_EGG
+
+        # When
+        with mock.patch(
+            "okonomiyaki.file_formats._package_info.compute_sha256",
+        ) as mocked_compute_sha256:
+            pkg_info = PackageInfo.from_egg(egg)
+
+        # Then
+        self.assertFalse(mocked_compute_sha256.called)


### PR DESCRIPTION
This PR:

* adds private APIs to `PackageInfo`, `LegacySpecDepend` and `EggMetadata` to build the corresponding objects from an egg + a pre-computed sha256
* use those APIs internally to avoid computing sha256 multiple times for an egg
* the public APIs `*.from_egg` only compute the checksum when it may be required, so that most eggs don't need any sha256 computation at all if given a path

It also enforces `PackageInfo.from_string` to take a unicode string.

@sjagoe 