### PR TITLE
Add semver v2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+XXXXXXXXXX   0.11.0:
+--------------------
+
+Improvements:
+
+  * SemanticVersion class added
+
 2015-00-01   0.10.0:
 --------------------
 

--- a/okonomiyaki/versions/__init__.py
+++ b/okonomiyaki/versions/__init__.py
@@ -2,5 +2,6 @@ from __future__ import absolute_import
 
 from .enpkg import EnpkgVersion
 from .pep386_workaround import PEP386WorkaroundVersion
+from .semver import SemanticVersion
 
-__all__ = ["EnpkgVersion", "PEP386WorkaroundVersion"]
+__all__ = ["EnpkgVersion", "PEP386WorkaroundVersion", "SemanticVersion"]

--- a/okonomiyaki/versions/semver.py
+++ b/okonomiyaki/versions/semver.py
@@ -4,9 +4,13 @@ from ..utils.py3compat import long
 
 
 _SEMVER_R = re.compile("""\
-    (\d+)\.(\d+)\.(\d+)   # main part
-    (-[0-9a-zA-Z-\.]+)?
-    (\+[0-9a-zA-Z-\.]+)?
+    (?P<major>\d+)
+    \.
+    (?P<minor>\d+)
+    \.
+    (?P<patch>\d+)
+    (?P<pre_release>-[0-9a-zA-Z-\.]+)?
+    (?P<build>\+[0-9a-zA-Z-\.]+)?
     $
 """, flags=re.VERBOSE)
 
@@ -114,13 +118,15 @@ class SemanticVersion(object):
         if m is None:
             raise ValueError("Invalid semver: {0!r}".format(s))
         else:
-            major = m.group(1)
-            minor = m.group(2)
-            patch = m.group(3)
+            d = m.groupdict()
 
-            pre_release = _parse_pre_release(m.group(4))
+            major = d["major"]
+            minor = d["minor"]
+            patch = d["patch"]
 
-            build = _parse_build(m.group(5))
+            pre_release = _parse_pre_release(d["pre_release"])
+
+            build = _parse_build(d["build"])
 
             _ensure_no_leading_zero(major, "Major")
             _ensure_no_leading_zero(minor, "Minor")

--- a/okonomiyaki/versions/semver.py
+++ b/okonomiyaki/versions/semver.py
@@ -135,10 +135,19 @@ class SemanticVersion(object):
         self.pre_release = pre_release or tuple()
         self.build = build or tuple()
 
-        self._comparable_parts = (
-            major, minor, patch,
-            _PrereleaseParts(self.pre_release),
-        )
+        # We cache _comparable_parts to avoid paying the relatively high cost
+        # of parsing the pre release parts for versions objects that won't be
+        # compared.
+        self._comparable_parts_value = None
+
+    @property
+    def _comparable_parts(self):
+        if self._comparable_parts_value is None:
+            self._comparable_parts_value = (
+                self.major, self.minor, self.patch,
+                _PrereleaseParts(self.pre_release),
+            )
+        return self._comparable_parts_value
 
     def __hash__(self):
         return hash(self._comparable_parts)

--- a/okonomiyaki/versions/semver.py
+++ b/okonomiyaki/versions/semver.py
@@ -22,7 +22,9 @@ def _ensure_no_leading_zero(value, name):
 
 def _parse_pre_release(s):
     if s is not None:
-        return tuple(part for part in s[1:].split("."))
+        # Remove `-` or `+`
+        without_prefix_s = s[1:]
+        return tuple(part for part in without_prefix_s.split("."))
     else:
         return None
 

--- a/okonomiyaki/versions/semver.py
+++ b/okonomiyaki/versions/semver.py
@@ -1,0 +1,161 @@
+import re
+
+
+_SEMVER_R = re.compile("""\
+    (\d+)\.(\d+)\.(\d+)   # main part
+    (-[0-9a-zA-Z-\.]+)?
+    (\+[0-9a-zA-Z-\.]+)?
+    $
+""", flags=re.VERBOSE)
+
+
+_PART_R = re.compile("[0-9a-zA-Z-]+")
+
+
+def _ensure_no_leading_zero(value, name):
+    if len(value) > 1 and value.startswith("0"):
+        msg = "{0} number cannot have leading 0: {1!r}".format(name, value)
+        raise ValueError(msg)
+
+
+def _parse_pre_release(s):
+    if s is not None:
+        return tuple(part for part in s[1:].split("."))
+    else:
+        return None
+
+
+def _parse_build(s):
+    return _parse_pre_release(s)
+
+
+def _convert_pre_release(part):
+    try:
+        value = int(part)
+    except ValueError:
+        return part
+    else:
+        _ensure_no_leading_zero(part, "Pre release part")
+        return value
+
+
+class _PrereleaseParts(object):
+    """ Private class used to compare the pre release and build parts. We need
+    this as an empty tuple need to compare greated than any non empty tuple.
+    """
+    def __init__(self, parts):
+        self._comparable_parts = tuple(_convert_pre_release(p) for p in parts)
+
+    def __hash__(self):
+        return hash(self._comparable_parts)
+
+    def __eq__(self, other):
+        assert isinstance(other, self.__class__)
+        return self._comparable_parts == other._comparable_parts
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __lt__(self, other):
+        assert isinstance(other, self.__class__)
+        if self._comparable_parts == other._comparable_parts:
+            return False
+        elif len(self._comparable_parts) == 0:
+            return False
+        elif len(other._comparable_parts) == 0:
+            return True
+        else:
+            return self._comparable_parts < other._comparable_parts
+
+    def __le__(self, other):
+        return self == other or self < other
+
+    def __gt__(self, other):
+        return not (self <= other)
+
+    def __ge__(self, other):
+        return not (self < other)
+
+
+class SemanticVersion(object):
+    @classmethod
+    def from_string(cls, s):
+        m = _SEMVER_R.match(s)
+
+        if m is None:
+            raise ValueError("Invalid semver: {0!r}".format(s))
+        else:
+            major = m.group(1)
+            minor = m.group(2)
+            patch = m.group(3)
+
+            pre_release = _parse_pre_release(m.group(4))
+
+            build = _parse_build(m.group(5))
+
+            _ensure_no_leading_zero(major, "Major")
+            _ensure_no_leading_zero(minor, "minor")
+            _ensure_no_leading_zero(patch, "patch")
+
+            return cls(int(major), int(minor), int(patch), pre_release, build)
+
+    def __init__(self, major, minor, patch, pre_release=None, build=None):
+        """ Private constructor, use one of the from_ ctors instead.
+        """
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.pre_release = pre_release or tuple()
+        self.build = build or tuple()
+
+        self._comparable_parts = (
+            major, minor, patch,
+            _PrereleaseParts(self.pre_release),
+        )
+
+    def __hash__(self):
+        return hash(self._comparable_parts)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        else:
+            return self._comparable_parts == other._comparable_parts
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __lt__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        else:
+            return self._comparable_parts < other._comparable_parts
+
+    def __le__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        else:
+            return self._comparable_parts <= other._comparable_parts
+
+    def __gt__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        else:
+            return self._comparable_parts > other._comparable_parts
+
+    def __ge__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        else:
+            return self._comparable_parts >= other._comparable_parts
+
+    def __str__(self):
+        s = "{0}.{1}.{2}".format(self.major, self.minor, self.patch)
+        if len(self.pre_release) > 0:
+            s += "-" + ".".join(str(v) for v in self.pre_release)
+        if len(self.build) > 0:
+            s += "+" + ".".join(str(v) for v in self.build)
+        return s
+
+    def __repr__(self):
+        return "SemanticVersion('{0}')".format(self)

--- a/okonomiyaki/versions/semver.py
+++ b/okonomiyaki/versions/semver.py
@@ -121,8 +121,8 @@ class SemanticVersion(object):
             build = _parse_build(m.group(5))
 
             _ensure_no_leading_zero(major, "Major")
-            _ensure_no_leading_zero(minor, "minor")
-            _ensure_no_leading_zero(patch, "patch")
+            _ensure_no_leading_zero(minor, "Minor")
+            _ensure_no_leading_zero(patch, "Patch")
 
             return cls(int(major), int(minor), int(patch), pre_release, build)
 

--- a/okonomiyaki/versions/semver.py
+++ b/okonomiyaki/versions/semver.py
@@ -78,6 +78,10 @@ class _PrereleaseParts(object):
 
 
 class SemanticVersion(object):
+    """ 'Semver' 2.0 implementation.
+
+    This class takes care of parsing and comparing semver objects.
+    """
     @classmethod
     def from_string(cls, s):
         m = _SEMVER_R.match(s)

--- a/okonomiyaki/versions/tests/test_semver.py
+++ b/okonomiyaki/versions/tests/test_semver.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 
 from ..enpkg import EnpkgVersion
@@ -169,10 +170,18 @@ class TestSemanticVersion(unittest.TestCase):
             '1.2.3-alpha.01+4+5',
         )
 
-        # When
+        # When/Then
         for v in invalid_strings:
             with self.assertRaises(ValueError):
                 SemanticVersion.from_string(v)
+
+        # Given
+        version_string = "1.2.03"
+        r_output = re.compile("Patch number cannot have leading 0: '03'$")
+
+        # When/Then
+        with self.assertRaisesRegexp(ValueError, r_output):
+            SemanticVersion.from_string(version_string)
 
     def test_other_object(self):
         # Given

--- a/okonomiyaki/versions/tests/test_semver.py
+++ b/okonomiyaki/versions/tests/test_semver.py
@@ -210,7 +210,55 @@ class TestSemanticVersion(unittest.TestCase):
         with self.assertRaises(TypeError):
             v > other
 
-    def test_pre_release_parts(self):
+
+class Test_PreReleaseParts(unittest.TestCase):
+    def test_empty_takes_precedence(self):
+        # Given
+        parts1 = _PrereleaseParts(tuple())
+        parts2 = _PrereleaseParts(("alpha", "1"))
+
+        # Then
+        self.assertFalse(parts1 < parts2)
+        self.assertFalse(parts1 <= parts2)
+        self.assertTrue(parts1 >= parts2)
+        self.assertTrue(parts1 > parts2)
+        self.assertFalse(parts1 == parts2)
+        self.assertTrue(parts1 != parts2)
+
+    def test_numerical_vs_string(self):
+        # Given
+        parts1 = _PrereleaseParts(("alpha", "beta"))
+        parts2 = _PrereleaseParts(("alpha", "1"))
+
+        # Then
+        self.assertFalse(parts1 < parts2)
+        self.assertFalse(parts1 <= parts2)
+        self.assertTrue(parts1 >= parts2)
+        self.assertTrue(parts1 > parts2)
+        self.assertFalse(parts1 == parts2)
+        self.assertTrue(parts1 != parts2)
+
+        # Given
+        parts = [
+            ("0", "3", "7"), ("alpha",), ("alpha", "1"), ("alpha", "2"),
+            # Note the 2 digits, to ensure we compare correctly purely
+            # numerical part
+            ("alpha", "10"),
+            ("beta",), ("rc",), ("rc", "1"), tuple()
+        ]
+
+        # Then
+        for left, right in zip(parts[:-1], parts[1:]):
+            left_parts = _PrereleaseParts(left)
+            right_parts = _PrereleaseParts(right)
+            self.assertTrue(left_parts < right_parts)
+            self.assertTrue(left_parts <= right_parts)
+            self.assertFalse(left_parts >= right_parts)
+            self.assertFalse(left_parts > right_parts)
+            self.assertFalse(left_parts == right_parts)
+            self.assertTrue(left_parts != right_parts)
+
+    def test_numerical_parts(self):
         # Given
         parts1 = _PrereleaseParts(("0", "3", "7"))
         parts2 = _PrereleaseParts(("0", "3", "7"))

--- a/okonomiyaki/versions/tests/test_semver.py
+++ b/okonomiyaki/versions/tests/test_semver.py
@@ -1,0 +1,236 @@
+import unittest
+
+from ..enpkg import EnpkgVersion
+from ..semver import SemanticVersion, _PrereleaseParts
+
+
+class TestSemanticVersion(unittest.TestCase):
+    def test_hashing(self):
+        # Given
+        s1 = "1.0.0+001"
+
+        # When
+        v1 = SemanticVersion.from_string(s1)
+        v2 = SemanticVersion.from_string(s1)
+
+        # Then
+        self.assertEqual(v1, v2)
+        self.assertEqual(hash(v1), hash(v2))
+
+    def test_roundtrip(self):
+        # Given
+        s1 = "1.0.0"
+
+        # When
+        v = SemanticVersion.from_string(s1)
+
+        # Then
+        self.assertEqual(str(v), s1)
+
+        # Given
+        s1 = "1.0.0-alpha"
+
+        # When
+        v = SemanticVersion.from_string(s1)
+
+        # Then
+        self.assertEqual(str(v), s1)
+
+        # Given
+        s1 = "1.0.0-alpha+001"
+
+        # When
+        v = SemanticVersion.from_string(s1)
+
+        # Then
+        self.assertEqual(str(v), s1)
+
+        # Given
+        s1 = "1.0.0+001"
+
+        # When
+        v = SemanticVersion.from_string(s1)
+
+        # Then
+        self.assertEqual(str(v), s1)
+
+        # Given
+        s1 = "1.0.0-0.3.7"
+
+        # When
+        v = SemanticVersion.from_string(s1)
+
+        # Then
+        self.assertEqual(str(v), s1)
+
+    def test_comparison_simple(self):
+        # Given
+        version_strings = ["1.0.0", "2.0.0", "2.1.0", "2.1.1"]
+
+        # When
+        versions = [SemanticVersion.from_string(s) for s in version_strings]
+
+        # Then
+        self.assertTrue(
+            versions[0] != versions[1] != versions[2] != versions[3]
+        )
+        self.assertTrue(versions[0] < versions[1] < versions[2] < versions[3])
+        self.assertTrue(versions[3] > versions[2] > versions[1] > versions[0])
+        self.assertTrue(
+            versions[0] <= versions[1] <= versions[2] <= versions[3]
+        )
+        self.assertTrue(
+            versions[3] >= versions[2] >= versions[1] >= versions[0]
+        )
+
+    def test_comparison_pre_release(self):
+        # Given
+        version_strings = [
+            "1.0.0-0.3.7", "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.2",
+            # Note the 2 digits, to ensure we compare correctly purely
+            # numerical part
+            "1.0.0-alpha.10",
+            "1.0.0-beta",
+            "1.0.0-rc",
+            "1.0.0-rc.1",
+            "1.0.0",
+        ]
+
+        # When
+        versions = [SemanticVersion.from_string(s) for s in version_strings]
+
+        # Then
+        self.assertTrue(
+            versions[0] < versions[1] < versions[2] < versions[3] <
+            versions[4] < versions[5] < versions[6] < versions[7] <
+            versions[8]
+        )
+        self.assertTrue(
+            versions[0] <= versions[1] <= versions[2] <= versions[3] <=
+            versions[4] <= versions[5] <= versions[6] <= versions[7] <=
+            versions[8]
+        )
+        self.assertTrue(
+            versions[8] >= versions[7] >= versions[6] >= versions[5] >=
+            versions[4] >= versions[3] >= versions[2] >= versions[1] >=
+            versions[0]
+        )
+        self.assertTrue(
+            versions[8] > versions[7] > versions[6] > versions[5] >
+            versions[4] > versions[3] > versions[2] > versions[1] >
+            versions[0]
+        )
+
+        # Given
+        s1 = "1.0.0-0.3.7"
+        s2 = "1.0.0-0.3.7"
+
+        # When
+        v1 = SemanticVersion.from_string(s1)
+        v2 = SemanticVersion.from_string(s2)
+
+        # Then
+        self.assertFalse(v1 < v2)
+        self.assertFalse(v1 > v2)
+        self.assertTrue(v1 <= v2)
+        self.assertTrue(v1 >= v2)
+
+    def test_comparison_build(self):
+        # Given
+        version_strings = ["1.0.0-alpha", "1.0.0-alpha+1", "1.0.0-alpha+2"]
+
+        # When
+        versions = [SemanticVersion.from_string(s) for s in version_strings]
+
+        # Then
+        self.assertTrue(versions[0] == versions[1] == versions[2])
+
+        # Given
+        version_strings = ["1.0.0-alpha+3", "1.0.0-beta+2", "1.0.0-rc+1"]
+
+        # When
+        versions = [SemanticVersion.from_string(s) for s in version_strings]
+
+        # Then
+        self.assertTrue(versions[0] < versions[1] < versions[2])
+
+    def test_invalid_versions(self):
+        # Given
+        invalid_strings = (
+            '1',
+            'v1',
+            '1.2.3.4',
+            '1.2',
+            '1.2.03',
+            '1.2b3',
+            '1.2.3b4',
+            'v12.34.5',
+            '1.2.3+4+5',
+            '1.2.3-alpha.01+4+5',
+        )
+
+        # When
+        for v in invalid_strings:
+            with self.assertRaises(ValueError):
+                SemanticVersion.from_string(v)
+
+    def test_other_object(self):
+        # Given
+        v = SemanticVersion.from_string("1.2.3")
+        other = EnpkgVersion.from_string("1.2.3-1")
+
+        # Then
+        self.assertFalse(v == other)
+        self.assertTrue(v != other)
+
+        # When/Then
+        with self.assertRaises(TypeError):
+            v >= other
+        with self.assertRaises(TypeError):
+            v <= other
+        with self.assertRaises(TypeError):
+            v < other
+        with self.assertRaises(TypeError):
+            v > other
+
+        # Given
+        v = SemanticVersion.from_string("1.2.3-alpha")
+
+        # Then
+        self.assertFalse(v == other)
+        self.assertTrue(v != other)
+
+        # When/Then
+        with self.assertRaises(TypeError):
+            v >= other
+        with self.assertRaises(TypeError):
+            v <= other
+        with self.assertRaises(TypeError):
+            v < other
+        with self.assertRaises(TypeError):
+            v > other
+
+    def test_pre_release_parts(self):
+        # Given
+        parts1 = _PrereleaseParts(("0", "3", "7"))
+        parts2 = _PrereleaseParts(("0", "3", "7"))
+
+        # Then
+        self.assertFalse(parts1 < parts2)
+        self.assertFalse(parts1 > parts2)
+        self.assertTrue(parts1 <= parts2)
+        self.assertTrue(parts1 >= parts2)
+        self.assertTrue(parts1 == parts2)
+        self.assertFalse(parts1 != parts2)
+
+        # Given
+        parts1 = _PrereleaseParts(("0", "3", "8"))
+        parts2 = _PrereleaseParts(("0", "3", "7"))
+
+        # Then
+        self.assertFalse(parts1 < parts2)
+        self.assertTrue(parts1 > parts2)
+        self.assertFalse(parts1 <= parts2)
+        self.assertTrue(parts1 >= parts2)
+        self.assertFalse(parts1 == parts2)
+        self.assertTrue(parts1 != parts2)


### PR DESCRIPTION
Cleaned up version of #105 

Looking at https://github.com/rbarrois/python-semanticversion, its comparison algo is almost one order of magnitude slower than our implementation (because it does int/string conversion at every step).

@sjagoe 