### PR TITLE
Add pep440

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Improvements:
 
   * SemanticVersion class added
   * MetadataVersion class added to easily manipulate metadata versions.
+  * PEP440Version class added.
   * runtime_metadata_factory function to parse and validate runtime packages.
   * __str__ is now implemented for EPDPlatform. The implementation support
     EPDPlatform.from_epd_string(str(epd_platform)) == epd_platform (#117)

--- a/okonomiyaki/versions/__init__.py
+++ b/okonomiyaki/versions/__init__.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 from .enpkg import EnpkgVersion
 from .metadata_version import MetadataVersion
 from .pep386_workaround import PEP386WorkaroundVersion
+from .pep440 import PEP440Version
 from .semver import SemanticVersion
 
 __all__ = [
     "EnpkgVersion", "MetadataVersion", "PEP386WorkaroundVersion",
-    "SemanticVersion"
+    "PEP440Version", "SemanticVersion"
 ]

--- a/okonomiyaki/versions/pep440.py
+++ b/okonomiyaki/versions/pep440.py
@@ -1,0 +1,117 @@
+""" Implementation of a subset of PEP440.
+
+Implementation adapted by the distlib.version package
+"""
+import re
+
+
+PEP440_VERSION_RE = re.compile(r'^v?(\d+!)?(\d+(\.\d+)*)((a|b|rc)(\d+))?'
+                               r'(\.(post)(\d+))?(\.(dev)(\d+))?'
+                               r'(\+([a-zA-Z\d]+(\.[a-zA-Z\d]+)?))?$')
+
+
+class PEP440Version(object):
+    """ A PEP440-compliant version object.
+
+    Note: replacements are not supported yet.
+    """
+    @classmethod
+    def from_string(cls, s):
+        m = PEP440_VERSION_RE.match(s)
+        if not m:
+            raise ValueError('Not a valid version: %s' % s)
+        groups = m.groups()
+        nums = tuple(int(v) for v in groups[1].split('.'))
+
+        if not groups[0]:
+            epoch = 0
+        else:
+            epoch = int(groups[0])
+        pre = groups[4:6]
+        post = groups[7:9]
+        dev = groups[10:12]
+        local = groups[13]
+        if pre == (None, None):
+            pre = ()
+        else:
+            pre = pre[0], int(pre[1])
+        if post == (None, None):
+            post = ()
+        else:
+            post = post[0], int(post[1])
+        if dev == (None, None):
+            dev = ()
+        else:
+            dev = dev[0], int(dev[1])
+        if local is None:
+            local = ()
+        else:
+            parts = []
+            for part in local.split('.'):
+                # to ensure that numeric compares as > lexicographic, avoid
+                # comparing them directly, but encode a tuple which ensures
+                # correct sorting
+                if part.isdigit():
+                    part = (1, int(part))
+                else:
+                    part = (0, part)
+                parts.append(part)
+            local = tuple(parts)
+        if not pre:
+            # either before pre-release, or final release and after
+            if not post and dev:
+                # before pre-release
+                pre = ('a', -1)     # to sort before a0
+            else:
+                pre = ('z',)        # to sort after all pre-releases
+        # now look at the state of post and dev.
+        if not post:
+            post = ('_',)   # sort before 'a'
+        if not dev:
+            dev = ('final',)
+
+        return cls(epoch, nums, pre, post, dev, local)
+
+    def __init__(self, epoch, nums, pre, post, dev, local):
+        self._release_clause = nums
+
+        nums = _strip_trailing_zeros(nums)
+
+        self._parts = (epoch, nums, pre, post, dev, local)
+
+    def __hash__(self):
+        return hash(self._parts)
+
+    def _ensure_compatible(self, other):
+        if type(self) != type(other):
+            raise TypeError('cannot compare %r and %r' % (self, other))
+
+    def __eq__(self, other):
+        self._ensure_compatible(other)
+        return self._parts == other._parts
+
+    def __ne__(self, other):
+        self._ensure_compatible(other)
+        return self._parts != other._parts
+
+    def __lt__(self, other):
+        self._ensure_compatible(other)
+        return self._parts < other._parts
+
+    def __le__(self, other):
+        self._ensure_compatible(other)
+        return self._parts <= other._parts
+
+    def __ge__(self, other):
+        self._ensure_compatible(other)
+        return self._parts >= other._parts
+
+    def __gt__(self, other):
+        self._ensure_compatible(other)
+        return self._parts > other._parts
+
+
+def _strip_trailing_zeros(nums):
+    while len(nums) > 1 and nums[-1] == 0:
+        nums = nums[:-1]
+    return nums

--- a/okonomiyaki/versions/pep440.py
+++ b/okonomiyaki/versions/pep440.py
@@ -129,12 +129,33 @@ class PEP440Version(object):
 
         self._parts = (epoch, nums, pre, post, dev, local)
 
+    @property
+    def normalized_string(self):
+        """ 'normalized' string, i.e. 0 in the numerical part are stripped.
+        """
+        return self._compute_string(*self._parts)
+
     def __hash__(self):
         return hash(self._parts)
 
     def _ensure_compatible(self, other):
         if type(self) != type(other):
             raise TypeError('cannot compare %r and %r' % (self, other))
+
+    def _compute_string(self, epoch, nums, pre, post, dev, local):
+        s = ""
+        if epoch:
+            s += str(epoch) + "!"
+        s += ".".join(str(i) for i in nums)
+        if pre and pre[0] not in (_MIN, _MAX):
+            s += pre[0] + str(pre[1])
+        if post and post[0] not in (_MIN, _MAX):
+            s += ".post" + str(post[1])
+        if dev and dev[0] not in (_MIN, _MAX):
+            s += ".dev" + str(dev[1])
+        if local:
+            s += "+" + ".".join(str(part[1]) for part in local)
+        return s
 
     def __eq__(self, other):
         self._ensure_compatible(other)
@@ -164,22 +185,9 @@ class PEP440Version(object):
         return "{0}('{1}')".format(self.__class__.__name__, str(self))
 
     def __str__(self):
-        s = ""
         nums = self._release_clause
         epoch, _, pre, post, dev, local = self._parts
-        if epoch:
-            s += str(epoch) + "!"
-        if nums:
-            s += ".".join(str(i) for i in nums)
-        if pre and pre[0] not in (_MIN, _MAX):
-            s += pre[0] + str(pre[1])
-        if post and post[0] not in (_MIN, _MAX):
-            s += ".post" + str(post[1])
-        if dev and dev[0] not in (_MIN, _MAX):
-            s += ".dev" + str(dev[1])
-        if local:
-            s += "+" + ".".join(str(part[1]) for part in local)
-        return s
+        return self._compute_string(epoch, nums, pre, post, dev, local)
 
 
 def _strip_trailing_zeros(nums):

--- a/okonomiyaki/versions/pep440.py
+++ b/okonomiyaki/versions/pep440.py
@@ -129,11 +129,17 @@ class PEP440Version(object):
 
         self._parts = (epoch, nums, pre, post, dev, local)
 
+        # Caching of the corresponnding properties
+        self._normalized_string = None
+        self._string = None
+
     @property
     def normalized_string(self):
         """ 'normalized' string, i.e. 0 in the numerical part are stripped.
         """
-        return self._compute_string(*self._parts)
+        if self._normalized_string is None:
+            self._normalized_string = self._compute_string(*self._parts)
+        return self._normalized_string
 
     def __hash__(self):
         return hash(self._parts)
@@ -185,9 +191,13 @@ class PEP440Version(object):
         return "{0}('{1}')".format(self.__class__.__name__, str(self))
 
     def __str__(self):
-        nums = self._release_clause
-        epoch, _, pre, post, dev, local = self._parts
-        return self._compute_string(epoch, nums, pre, post, dev, local)
+        if self._string is None:
+            nums = self._release_clause
+            epoch, _, pre, post, dev, local = self._parts
+            self._string = self._compute_string(
+                epoch, nums, pre, post, dev, local
+            )
+        return self._string
 
 
 def _strip_trailing_zeros(nums):

--- a/okonomiyaki/versions/pep440.py
+++ b/okonomiyaki/versions/pep440.py
@@ -1,6 +1,6 @@
 """ Implementation of a subset of PEP440.
 
-Implementation adapted by the distlib.version package
+Implementation adapted from the distlib.version package
 """
 import re
 
@@ -129,7 +129,7 @@ class PEP440Version(object):
 
         self._parts = (epoch, nums, pre, post, dev, local)
 
-        # Caching of the corresponnding properties
+        # Caching of the corresponding properties
         self._normalized_string = None
         self._string = None
 

--- a/okonomiyaki/versions/tests/test_pep440.py
+++ b/okonomiyaki/versions/tests/test_pep440.py
@@ -71,6 +71,21 @@ class TestMinMax(unittest.TestCase):
 
 
 class TestPEP440Version(unittest.TestCase):
+    def test_normalized_string(self):
+        # Given
+        version_strings = (
+            ("1.0.0", "1"),
+            ("1!1.0.0", "1!1"),
+            ("1.0.0.dev1", "1.dev1"),
+            ("2!1.0.0rc2.post2.dev1", "2!1rc2.post2.dev1"),
+            ("2!1.0.0rc2.post2.dev1+1.2a", "2!1rc2.post2.dev1+1.2a"),
+        )
+
+        # When/Then
+        for version_string, normalized in version_strings:
+            version = V(version_string)
+            self.assertEqual(version.normalized_string, normalized)
+
     def test_string(self):
         # Given
         version_strings = (

--- a/okonomiyaki/versions/tests/test_pep440.py
+++ b/okonomiyaki/versions/tests/test_pep440.py
@@ -37,7 +37,7 @@ class TestPEP440Version(unittest.TestCase):
         )
 
         self.assertTrue(
-            V('1.0.post456.dev623') < V('1.0.post456')  < V('1.0.post1234')
+            V('1.0.post456.dev623') < V('1.0.post456') < V('1.0.post1234')
         )
 
         self.assertTrue(
@@ -69,7 +69,7 @@ class TestPEP440Version(unittest.TestCase):
             < V('1.0.post456+1')
             < V('1.0.post456+1.1')
         )
-        
+
         self.assertLessEqual(V('1.2.0rc1'), V('1.2.0'))
         self.assertGreater(V('1.0'), V('1.0rc2'))
         self.assertGreater(V('1.0'), V('1.0rc2'))

--- a/okonomiyaki/versions/tests/test_pep440.py
+++ b/okonomiyaki/versions/tests/test_pep440.py
@@ -1,12 +1,90 @@
 import unittest
 
-from ..pep440 import PEP440Version
+from ..pep440 import _MIN, _MAX, PEP440Version
 
 
 V = PEP440Version.from_string
 
 
+class TestMinMax(unittest.TestCase):
+    def test_min(self):
+        self.assertFalse(_MIN == 1)
+        self.assertFalse(_MIN == _MAX)
+        self.assertFalse(_MIN == "0")
+        self.assertTrue(_MIN == _MIN)
+
+        self.assertTrue(_MIN != 1)
+        self.assertTrue(_MIN != _MAX)
+        self.assertTrue(_MIN != "0")
+        self.assertFalse(_MIN != _MIN)
+
+        self.assertTrue(_MIN < 1)
+        self.assertTrue(_MIN < _MAX)
+        self.assertTrue(_MIN < "0")
+        self.assertFalse(_MIN < _MIN)
+
+        self.assertTrue(_MIN <= 1)
+        self.assertTrue(_MIN <= _MAX)
+        self.assertTrue(_MIN <= "0")
+        self.assertTrue(_MIN <= _MIN)
+
+        self.assertFalse(_MIN >= 1)
+        self.assertFalse(_MIN >= _MAX)
+        self.assertFalse(_MIN >= "0")
+        self.assertTrue(_MIN >= _MIN)
+
+        self.assertFalse(_MIN > 1)
+        self.assertFalse(_MIN > _MAX)
+        self.assertFalse(_MIN > "0")
+        self.assertFalse(_MIN > _MIN)
+
+    def test_max(self):
+        self.assertFalse(_MAX == _MIN)
+        self.assertFalse(_MAX == 1)
+        self.assertFalse(_MAX == "0")
+        self.assertTrue(_MAX == _MAX)
+
+        self.assertTrue(_MAX != _MIN)
+        self.assertTrue(_MAX != 1)
+        self.assertTrue(_MAX != "0")
+        self.assertFalse(_MAX != _MAX)
+
+        self.assertFalse(_MAX < 1)
+        self.assertFalse(_MAX < _MIN)
+        self.assertFalse(_MAX < "0")
+        self.assertFalse(_MAX < _MAX)
+
+        self.assertFalse(_MAX <= 1)
+        self.assertFalse(_MAX <= _MIN)
+        self.assertFalse(_MAX <= "0")
+        self.assertTrue(_MAX <= _MAX)
+
+        self.assertTrue(_MAX >= 1)
+        self.assertTrue(_MAX >= _MIN)
+        self.assertTrue(_MAX >= "0")
+        self.assertTrue(_MAX >= _MAX)
+
+        self.assertTrue(_MAX > 1)
+        self.assertTrue(_MAX > _MIN)
+        self.assertTrue(_MAX > "0")
+        self.assertFalse(_MAX > _MAX)
+
+
 class TestPEP440Version(unittest.TestCase):
+    def test_string(self):
+        # Given
+        version_strings = (
+            "1.0.0",
+            "1!1.0.0",
+            "1.0.0.dev1",
+            "2!1.0.0rc2.post2.dev1",
+            "2!1.0.0rc2.post2.dev1+1.2a",
+        )
+
+        # When/Then
+        for version_string in version_strings:
+            self.assertEqual(str(V(version_string)), version_string)
+
     def test_comparison(self):
         self.assertTrue(V("1.2.0") == V("1.2"))
         self.assertFalse(V("1.2.0") == V("1.2.3"))

--- a/okonomiyaki/versions/tests/test_pep440.py
+++ b/okonomiyaki/versions/tests/test_pep440.py
@@ -1,0 +1,108 @@
+import unittest
+
+from ..pep440 import PEP440Version
+
+
+V = PEP440Version.from_string
+
+
+class TestPEP440Version(unittest.TestCase):
+    def test_comparison(self):
+        self.assertTrue(V("1.2.0") == V("1.2"))
+        self.assertFalse(V("1.2.0") == V("1.2.3"))
+        self.assertTrue(V("1.2.0") != V("1.2.3"))
+        self.assertTrue(V("1.2.0") < V("1.2.3"))
+        self.assertFalse(V("1.2.3") < V("1.2.0"))
+        self.assertTrue(V("1.2.0") <= V("1.2.3"))
+        self.assertFalse(V("1.2.3") <= V("1.2.0"))
+        self.assertTrue(V("1.2.0") >= V("1.2.0"))
+        self.assertTrue(V("1.2.3") >= V("1.2.0"))
+        self.assertFalse(V("1.2.0") >= V("1.2.3"))
+        self.assertFalse(V("1.2.0rc1") >= V("1.2.0"))
+        self.assertTrue(V("1.0") > V("1.0b2"))
+        self.assertTrue(V("1.0") > V("1.0rc2"))
+        self.assertTrue(V("1.0rc2") > V("1.0rc1"))
+        self.assertTrue(V("1.0rc4") > V("1.0rc1"))
+
+        self.assertTrue(
+            V('1.0') > V('1.0rc2') > V('1.0rc1') > V('1.0b2') > V('1.0b1')
+            > V('1.0a2') > V('1.0a1')
+        )
+        self.assertTrue(
+            V('1.0.0') > V('1.0.0rc2') > V('1.0.0rc1') > V('1.0.0b2')
+            > V('1.0.0b1') > V('1.0.0a2') > V('1.0.0a1')
+        )
+        self.assertTrue(
+            V('1.0') < V('1.0.post456.dev623')
+        )
+
+        self.assertTrue(
+            V('1.0.post456.dev623') < V('1.0.post456')  < V('1.0.post1234')
+        )
+
+        self.assertTrue(
+            V('1.0.dev7')
+            < V('1.0.dev18')
+            < V('1.0.dev456')
+            < V('1.0.dev1234')
+            < V('1.0a1')
+            < V('1.0a2.dev456')
+            < V('1.0a2')
+            # e.g. need to do a quick post release on 1.0a2
+            < V('1.0a2.post1.dev456')
+            < V('1.0a2.post1')
+            < V('1.0b1.dev456')
+            < V('1.0b2')
+            < V('1.0rc1.dev456')
+            < V('1.0rc1')
+            < V('1.0rc1+1')
+            < V('1.0rc1+1.1')
+            < V('1.0rc2')
+            < V('1.0')
+            < V('1.0+1')
+            < V('1.0+1.1')
+            # development version of a post release
+            < V('1.0.post456.dev623')
+            < V('1.0.post456.dev623+1')
+            < V('1.0.post456.dev623+1.1')
+            < V('1.0.post456')
+            < V('1.0.post456+1')
+            < V('1.0.post456+1.1')
+        )
+        
+        self.assertLessEqual(V('1.2.0rc1'), V('1.2.0'))
+        self.assertGreater(V('1.0'), V('1.0rc2'))
+        self.assertGreater(V('1.0'), V('1.0rc2'))
+        self.assertGreater(V('1.0rc2'), V('1.0rc1'))
+        self.assertGreater(V('1.0rc4'), V('1.0rc1'))
+
+    def test_hashing(self):
+        # Given
+        v1 = V("1.2.0")
+        v2 = V("1.2.0")
+
+        # When/Then
+        self.assertEqual(hash(v1), hash(v2))
+
+    def test_invalid(self):
+        # Given
+        left = V("1.0")
+        right = "1.0"
+
+        # When/Then
+        with self.assertRaises(TypeError):
+            left == right
+        with self.assertRaises(TypeError):
+            left != right
+        with self.assertRaises(TypeError):
+            left < right
+        with self.assertRaises(TypeError):
+            left <= right
+        with self.assertRaises(TypeError):
+            left >= right
+        with self.assertRaises(TypeError):
+            left > right
+
+        # When/Then
+        with self.assertRaises(ValueError):
+            V("a")

--- a/okonomiyaki/versions/tests/test_pep440.py
+++ b/okonomiyaki/versions/tests/test_pep440.py
@@ -159,6 +159,7 @@ class TestPEP440Version(unittest.TestCase):
             < V('1.0.post456.dev623+1')
             < V('1.0.post456.dev623+1.1')
             < V('1.0.post456')
+            < V('1.0.post456+a.1')
             < V('1.0.post456+1')
             < V('1.0.post456+1.1')
         )


### PR DESCRIPTION
Implements the basic parts PEP440. It is not complete as it does not implement the replacements, but since those are not implemented in pip either, I don't think it is a big deal for now.

We don't use distlib's version as our version is ~50 % faster (we don't parse the string twice !). I also believe our implementation is simpler.

@jvkersch 