### PR TITLE
Handle unsupported metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 2.6
     - 2.7
     - 3.4
+    - 3.5
     - pypy
 
 install:

--- a/okonomiyaki/errors.py
+++ b/okonomiyaki/errors.py
@@ -7,7 +7,16 @@ class InvalidPackageFormat(OkonomiyakiError):
 
 
 class UnsupportedMetadata(InvalidPackageFormat):
-    pass
+    def __init__(self, metadata_version, *a, **kw):
+        self.metadata_version = metadata_version
+        super(UnsupportedMetadata, self).__init__(*a, **kw)
+
+    def __str__(self):
+        if len(self.args) >= 1:
+            return self.args[0]
+        else:
+            return "Unsupported metadata_version: {0!r}".format(
+                str(self.metadata_version))
 
 
 class InvalidEggName(InvalidPackageFormat):

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -775,6 +775,33 @@ class EggMetadata(object):
         return cls(raw_name, version, platform, python_tag, abi_tag,
                    dependencies, pkg_info, summary, metadata_version)
 
+    @classmethod
+    def from_egg_metadata(cls, egg_metadata, **kw):
+        """ Utility ctor to create a new EggMetadata instance from an existing
+        one, potentially updating some metadata.
+
+        Any keyword argument (except `egg_metadata`) is understood as an
+        argument to EggMetadata.__init__.
+
+        Parameters
+        ----------
+        egg_metadata: EggMetadata
+        """
+        passed_kw = {"raw_name": egg_metadata._raw_name}
+
+        for k in (
+            "version", "platform", "python", "abi_tag", "pkg_info", "summary",
+            "metadata_version"
+        ):
+            passed_kw[k] = getattr(egg_metadata, k)
+        passed_kw["dependencies"] = Dependencies(
+            egg_metadata.runtime_dependencies
+        )
+
+        passed_kw.update(**kw)
+
+        return cls(**passed_kw)
+
     def __init__(self, raw_name, version, platform, python, abi_tag,
                  dependencies, pkg_info, summary, metadata_version=None):
         """ EggMetadata instances encompass Enthought egg metadata.

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -102,7 +102,7 @@ def parse_rawspec(spec_string):
     ):
         msg = ("Invalid metadata version: {0!r}. You may need to update to a "
                "more recent okonomiyaki version".format(metadata_version))
-        raise UnsupportedMetadata(msg)
+        raise UnsupportedMetadata(metadata_version, msg)
 
     res = {}
 

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -14,6 +14,7 @@ else:
     import unittest
 
 from ...errors import InvalidEggName, InvalidMetadata, UnsupportedMetadata
+from ...utils.test_data import NOSE_1_3_4_OSX_X86_64
 from ...platforms import EPDPlatform
 from ...platforms.legacy import LegacyEPDPlatform
 from ...versions import EnpkgVersion, MetadataVersion
@@ -821,6 +822,35 @@ class TestEggInfo(unittest.TestCase):
         # When/Then
         with self.assertRaises(UnsupportedMetadata):
             metadata._spec_depend
+
+    def test_support_lower_compatible_version(self):
+        # Given
+        spec_depend = textwrap.dedent(b"""\
+            metadata_version = '1.1'
+            name = 'nose'
+            version = '1.3.4'
+            build = 1
+
+            arch = 'amd64'
+            platform = 'linux2'
+            osdist = 'RedHat_5'
+            python = '2.7'
+            packages = []\n""")
+
+        egg = NOSE_1_3_4_OSX_X86_64
+        metadata = EggMetadata.from_egg(egg)
+
+        # When
+        metadata = EggMetadata.from_egg_metadata(
+            metadata, metadata_version=M("1.1")
+        )
+
+        # Then
+        self.assertEqual(metadata.name, "nose")
+        self.assertEqual(metadata.metadata_version, M("1.1"))
+        self.assertMultiLineEqual(
+            metadata._spec_depend.to_string(), spec_depend
+        )
 
     def test_from_cross_platform_egg(self):
         # Given

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -225,7 +225,7 @@ packages = [
         )
 
         s = textwrap.dedent("""\
-            metadata_version = "{}"
+            metadata_version = "{0}"
 
             name = "foo"
             version = "1.0"
@@ -783,8 +783,11 @@ class TestEggInfo(unittest.TestCase):
             to_copy = set(zi.namelist()) - set(("EGG-INFO/spec/depend",))
             with zipfile2.ZipFile(new_egg, "w") as zo:
                 for archive in to_copy:
-                    with zi.open(archive) as fp:
+                    fp = zi.open(archive)
+                    try:
                         zo.writestr(archive, fp.read())
+                    finally:
+                        fp.close()
 
                 zo.writestr("EGG-INFO/spec/depend", spec_depend_string)
 
@@ -792,7 +795,7 @@ class TestEggInfo(unittest.TestCase):
 
     def test_support_higher_compatible_version(self):
         # Given
-        spec_depend = textwrap.dedent(b"""\
+        spec_depend = textwrap.dedent("""\
             metadata_version = '1.4'
             name = 'enstaller'
             version = '4.5.0'
@@ -825,7 +828,7 @@ class TestEggInfo(unittest.TestCase):
 
     def test_support_lower_compatible_version(self):
         # Given
-        spec_depend = textwrap.dedent(b"""\
+        spec_depend = textwrap.dedent("""\
             metadata_version = '1.1'
             name = 'nose'
             version = '1.3.4'

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -241,8 +241,7 @@ packages = [
             platform_tag = "macosx_10_6_i386"
             python_tag = "cp27"
 
-            packages = []""".format(str(unsupported))
-        )
+            packages = []""".format(str(unsupported)))
 
         # When/Then
         with self.assertRaises(UnsupportedMetadata):

--- a/okonomiyaki/platforms/abi.py
+++ b/okonomiyaki/platforms/abi.py
@@ -59,14 +59,14 @@ def default_abi(platform, implementation, implementation_version):
         )
 
     msg = "Unsupported platform/version combo for {0!r}: {1!r}/{2!r}".format(
-        implementation, platform, implementation_version
+        implementation, platform, str(implementation_version)
     )
 
     if implementation == "cpython":
         return _default_cpython_abi(platform, implementation_version)
     elif implementation == "pypy":
         if platform.os == WINDOWS:
-            if implementation_version < RuntimeVersion.from_string("2.7"):
+            if implementation_version <= RuntimeVersion.from_string("4.1"):
                 return u"msvc2008"
             else:
                 raise OkonomiyakiError(msg)

--- a/okonomiyaki/platforms/tests/test_abi.py
+++ b/okonomiyaki/platforms/tests/test_abi.py
@@ -30,7 +30,7 @@ class TestDefaultABI(unittest.TestCase):
         # Given
         args = (
             ("win_x86", "cpython", "3.6.0+1"),
-            ("win_x86", "pypy", "2.7.0+1"),
+            ("win_x86", "pypy", "4.1.0+1"),
             ("rh5_x86_64", "r", "3.0.0+1"),
         )
 

--- a/okonomiyaki/runtimes/runtime_info.py
+++ b/okonomiyaki/runtimes/runtime_info.py
@@ -182,7 +182,7 @@ def runtime_info_from_json(json_data):
     klass = _RUNTIME_INFO_JSON_FACTORY.get(key)
     if klass is None:
         msg = "Combination {0!r} is not supported".format(key)
-        raise UnsupportedMetadata(msg)
+        raise UnsupportedMetadata(metadata_version, msg)
     else:
         return klass._from_json_dict(json_data)
 

--- a/okonomiyaki/runtimes/runtime_metadata.py
+++ b/okonomiyaki/runtimes/runtime_metadata.py
@@ -112,8 +112,7 @@ class IRuntimeMetadataV1(IRuntimeMetadata):
 
         metadata_version = metadata_dict["metadata_version"]
         if metadata_version != "1.0":
-            msg = "Unsupported metadata version: {0!r}"
-            raise UnsupportedMetadata(msg.format(metadata_version))
+            raise UnsupportedMetadata(metadata_version)
 
         return cls._from_json_dict(metadata_dict)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy,flake8
+envlist = py26,py27,py34,py35,pypy,flake8
 
 [testenv]
 deps= -rdev_requirements.txt


### PR DESCRIPTION
This PR does the following:

* change `UnsupportedMetadata` exception to store `metadata_version` 
* reject incompatible `metadata_version` when reading/writing egg metadata. When reading, is considered as invalid an unsupported major metadata version. When writing, any metadata version not fully supported is rejected (to avoid data loss).
* `EggMetadata.is_strictly_supported` property is False when an unsupported but backward compatible metadata_version is detected (e.g. `1.5` metadata_version w/ okonomiyaki only supporting up to `1.3`)
* Add support for 3.5 in CI

@sjagoe 