### PR TITLE
Add platform abi

### DIFF
--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -332,23 +332,29 @@ def _guess_python_tag(pyver):
             return "cp" + major + minor
 
 
-def _guess_platform_abi(platform, implementation_version):
-    """ Guess platform_abi from the given epd_platform and implementation.
+def _guess_platform_abi(platform, implementation):
+    """ Guess platform_abi from the given platform and implementation.
 
-    None may be returned
+    May be None.
 
     Parameters
     ----------
     platform: Platform
         May be None.
-    implementation_version : RuntimeVersion or str
-        The runtime version.
+    implementation: PythonImplementation
+        May be None.
     """
     if platform is None:
         return None
     else:
+        if implementation is None:
+            # All our eggs so far have been python 2-only
+            implementation = PythonImplementation.from_string("cp27")
+        implementation_version = "{}.{}".format(
+            implementation.major, implementation.minor
+        )
         return default_abi(
-            platform, "cpython", implementation_version
+            platform, implementation.kind, implementation_version
         )
 
 

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -9,7 +9,7 @@ from ..errors import (
     InvalidRequirementString, InvalidEggName, InvalidMetadata,
     InvalidMetadataField, MissingMetadata, UnsupportedMetadata
 )
-from ..platforms import EPDPlatform, PythonImplementation
+from ..platforms import EPDPlatform, PythonImplementation, default_abi
 from ..platforms.legacy import LegacyEPDPlatform
 from ..utils import compute_sha256, parse_assignments
 from ..utils.py3compat import StringIO, string_types
@@ -330,6 +330,26 @@ def _guess_python_tag(pyver):
             minor = m.groupdict()["minor"]
 
             return "cp" + major + minor
+
+
+def _guess_platform_abi(platform, implementation_version):
+    """ Guess platform_abi from the given epd_platform and implementation.
+
+    None may be returned
+
+    Parameters
+    ----------
+    platform: Platform
+        May be None.
+    implementation_version : RuntimeVersion or str
+        The runtime version.
+    """
+    if platform is None:
+        return None
+    else:
+        return default_abi(
+            platform, "cpython", implementation_version
+        )
 
 
 _METADATA_DEFAULT_VERSION_STRING = "1.3"

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -374,7 +374,7 @@ def _guess_platform_abi(platform, implementation):
         if implementation is None:
             # All our eggs so far have been python 2-only
             implementation = PythonImplementation.from_string("cp27")
-        implementation_version = "{}.{}".format(
+        implementation_version = "{0}.{1}".format(
             implementation.major, implementation.minor
         )
         return default_abi(

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -193,6 +193,7 @@ packages = [
             depend._epd_legacy_platform,
             LegacyEPDPlatform.from_epd_platform_string("win-32")
         )
+        self.assertEqual(depend.platform_abi, "msvc2008")
 
     def test_format_1_3(self):
         r_depend = """\
@@ -220,6 +221,37 @@ packages = [
         self.assertEqual(depend.python_tag, "cp27")
         self.assertEqual(depend.abi_tag, "cp27m")
         self.assertEqual(depend.platform_tag, "win32")
+        self.assertEqual(depend.platform_abi, "msvc2008")
+
+    def test_format_1_4(self):
+        r_depend = """\
+metadata_version = "1.4"
+name= "numpy_debug"
+version = "1.9.2"
+build = 3
+
+arch = 'x86'
+platform = 'win32'
+osdist = None
+
+python = "2.7"
+python_tag = "cp27"
+abi_tag = "cp27m"
+platform_tag = "win32"
+
+platform_abi = "msvc2008"
+
+packages = [
+]
+"""
+        depend = LegacySpecDepend.from_string(r_depend)
+
+        # Then
+        self.assertEqual(depend._metadata_version, M("1.4"))
+        self.assertEqual(depend.python_tag, "cp27")
+        self.assertEqual(depend.abi_tag, "cp27m")
+        self.assertEqual(depend.platform_tag, "win32")
+        self.assertEqual(depend.platform_abi, "msvc2008")
 
     def test_unsupported_metadata_version(self):
         # Given
@@ -332,6 +364,7 @@ packages = []
 
         # Then
         self.assertIsNone(spec_depend.abi_tag, None)
+        self.assertEqual(spec_depend.platform_abi, "darwin")
 
     def test_default_pure_python_egg(self):
         # Given
@@ -353,6 +386,7 @@ packages = []
 
         # Then
         self.assertEqual(spec_depend.abi_tag, "cp27m")
+        self.assertEqual(spec_depend.platform_abi, "darwin")
 
     def test_default_extension_python_egg(self):
         # Given
@@ -376,6 +410,30 @@ packages = [
 
         # Then
         self.assertEqual(spec_depend.abi_tag, "cp27m")
+        self.assertEqual(spec_depend.platform_abi, "darwin")
+
+    def test_default_no_python_egg(self):
+        # Given
+        spec_depend_string = """\
+metadata_version = '1.1'
+name = 'MKL'
+version = '11.1.4'
+build = 1
+
+arch = 'amd64'
+platform = 'win32'
+osdist = 'Windows'
+python = None
+packages = [
+]
+"""
+
+        # When
+        spec_depend = LegacySpecDepend.from_string(spec_depend_string)
+
+        # Then
+        self.assertIsNone(spec_depend.abi_tag)
+        self.assertEqual(spec_depend.platform_abi, "msvc2008")
 
     def test_default_pure_python_egg_pypi(self):
         # Given
@@ -399,6 +457,7 @@ packages = [
 
         # Then
         self.assertIsNone(spec_depend.abi_tag)
+        self.assertIsNone(spec_depend.platform_abi)
 
     def test_to_string(self):
         # Given
@@ -973,10 +1032,78 @@ class TestEggInfo(unittest.TestCase):
 
         return new_egg
 
-    def test_support_higher_compatible_version(self):
+    def test_platform_abi(self):
         # Given
         spec_depend = textwrap.dedent("""\
             metadata_version = '1.4'
+            name = 'Qt'
+            version = '4.8.7'
+            build = 4
+
+            arch = 'amd64'
+            platform = 'win32'
+            osdist = None
+            python = None
+
+            python_tag = None
+            abi_tag = None
+            platform_tag = 'win_amd64'
+
+            platform_abi = 'msvc2010'
+
+            packages = []""")
+
+        r_spec_depend = textwrap.dedent("""\
+            metadata_version = '1.4'
+            name = 'Qt'
+            version = '4.8.7'
+            build = 4
+
+            arch = 'amd64'
+            platform = 'win32'
+            osdist = None
+            python = None
+
+            python_tag = None
+            abi_tag = None
+            platform_tag = 'win_amd64'
+
+            platform_abi = 'msvc2015'
+
+            packages = []
+        """)
+
+        egg = self._override_spec_depend(ENSTALLER_EGG, spec_depend)
+
+        # When
+        metadata = EggMetadata.from_egg(egg)
+
+        # Then
+        self.assertEqual(metadata.name, "qt")
+        self.assertEqual(metadata.metadata_version, M("1.4"))
+        self.assertIs(metadata.is_strictly_supported, True)
+        self.assertEqual(metadata.platform_abi, "msvc2010")
+        self.assertEqual(metadata.platform_abi_string, "msvc2010")
+
+        # When
+        metadata.platform_abi = None
+
+        # Then
+        self.assertIs(metadata.platform_abi, None)
+        self.assertEqual(metadata.platform_abi_string, "none")
+
+        # When
+        metadata.platform_abi = "msvc2015"
+
+        # Then
+        self.assertMultiLineEqual(
+            metadata._spec_depend.to_string(), r_spec_depend
+        )
+
+    def test_support_higher_compatible_version(self):
+        # Given
+        spec_depend = textwrap.dedent("""\
+            metadata_version = '1.5'
             name = 'enstaller'
             version = '4.5.0'
             build = 1
@@ -990,6 +1117,8 @@ class TestEggInfo(unittest.TestCase):
             abi_tag = None
             platform_tag = None
 
+            platform_abi = None
+
             packages = []""")
 
         egg = self._override_spec_depend(ENSTALLER_EGG, spec_depend)
@@ -999,7 +1128,7 @@ class TestEggInfo(unittest.TestCase):
 
         # Then
         self.assertEqual(metadata.name, "enstaller")
-        self.assertEqual(metadata.metadata_version, M("1.4"))
+        self.assertEqual(metadata.metadata_version, M("1.5"))
         self.assertIs(metadata.is_strictly_supported, False)
 
         # When/Then

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -18,7 +18,7 @@ from ...errors import (
     UnsupportedMetadata)
 from ...utils import tempdir
 from ...utils.test_data import NOSE_1_3_4_OSX_X86_64
-from ...platforms import EPDPlatform
+from ...platforms import EPDPlatform, PythonImplementation
 from ...platforms.legacy import LegacyEPDPlatform
 from ...versions import EnpkgVersion, MetadataVersion, RuntimeVersion
 
@@ -558,11 +558,11 @@ packages = []
 class TestGuessPlatformAbi(unittest.TestCase):
     def test_python_27(self):
         # Given
-        implementation_version = RuntimeVersion.from_string("2.7")
+        implementation = PythonImplementation.from_string("cp27")
         platform = EPDPlatform.from_epd_string("rh5-64").platform
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertEqual(abi, "gnu")
@@ -571,7 +571,7 @@ class TestGuessPlatformAbi(unittest.TestCase):
         platform = EPDPlatform.from_epd_string("osx-64").platform
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertEqual(abi, "darwin")
@@ -580,18 +580,18 @@ class TestGuessPlatformAbi(unittest.TestCase):
         platform = EPDPlatform.from_epd_string("win-64").platform
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertEqual(abi, "msvc2008")
 
     def test_python_34(self):
         # Given
-        implementation_version = RuntimeVersion.from_string("3.4")
+        implementation = PythonImplementation.from_string("cp34")
         platform = EPDPlatform.from_epd_string("rh5-64").platform
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertEqual(abi, "gnu")
@@ -600,7 +600,7 @@ class TestGuessPlatformAbi(unittest.TestCase):
         platform = EPDPlatform.from_epd_string("osx-64").platform
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertEqual(abi, "darwin")
@@ -609,18 +609,18 @@ class TestGuessPlatformAbi(unittest.TestCase):
         platform = EPDPlatform.from_epd_string("win-64").platform
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertEqual(abi, "msvc2010")
 
     def test_python_35(self):
         # Given
-        implementation_version = RuntimeVersion.from_string("3.5")
+        implementation = PythonImplementation.from_string("cp35")
         platform = EPDPlatform.from_epd_string("rh5-64").platform
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertEqual(abi, "gnu")
@@ -629,7 +629,7 @@ class TestGuessPlatformAbi(unittest.TestCase):
         platform = EPDPlatform.from_epd_string("osx-64").platform
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertEqual(abi, "darwin")
@@ -638,30 +638,58 @@ class TestGuessPlatformAbi(unittest.TestCase):
         platform = EPDPlatform.from_epd_string("win-64").platform
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertEqual(abi, "msvc2015")
 
     def test_no_platform(self):
         # Given
-        implementation_version = RuntimeVersion.from_string("2.7")
+        implementation = PythonImplementation.from_string("cp27")
         platform = None
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertIsNone(abi)
 
         # Given
-        implementation_version = RuntimeVersion.from_string("3.4")
+        implementation = PythonImplementation.from_string("cp34")
 
         # When
-        abi = _guess_platform_abi(platform, implementation_version)
+        abi = _guess_platform_abi(platform, implementation)
 
         # Then
         self.assertIsNone(abi)
+
+    def test_no_python_implementation(self):
+        # Given
+        platform = EPDPlatform.from_epd_string("rh5-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, None)
+
+        # Then
+        self.assertEqual(abi, "gnu")
+
+        # Given
+        platform = EPDPlatform.from_epd_string("osx-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, None)
+
+        # Then
+        self.assertEqual(abi, "darwin")
+
+        # Given
+        platform = EPDPlatform.from_epd_string("win-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, None)
+
+        # Then
+        self.assertEqual(abi, "msvc2008")
 
 
 class TestEggName(unittest.TestCase):

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -20,11 +20,11 @@ from ...utils import tempdir
 from ...utils.test_data import NOSE_1_3_4_OSX_X86_64
 from ...platforms import EPDPlatform
 from ...platforms.legacy import LegacyEPDPlatform
-from ...versions import EnpkgVersion, MetadataVersion
+from ...versions import EnpkgVersion, MetadataVersion, RuntimeVersion
 
 from .._egg_info import (
     Requirement, EggMetadata, LegacySpecDepend, parse_rawspec,
-    split_egg_name
+    split_egg_name, _guess_platform_abi
 )
 
 from .common import (
@@ -553,6 +553,115 @@ packages = []
 
         # Then
         self.assertIsNone(spec_depend.platform_tag)
+
+
+class TestGuessPlatformAbi(unittest.TestCase):
+    def test_python_27(self):
+        # Given
+        implementation_version = RuntimeVersion.from_string("2.7")
+        platform = EPDPlatform.from_epd_string("rh5-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertEqual(abi, "gnu")
+
+        # Given
+        platform = EPDPlatform.from_epd_string("osx-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertEqual(abi, "darwin")
+
+        # Given
+        platform = EPDPlatform.from_epd_string("win-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertEqual(abi, "msvc2008")
+
+    def test_python_34(self):
+        # Given
+        implementation_version = RuntimeVersion.from_string("3.4")
+        platform = EPDPlatform.from_epd_string("rh5-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertEqual(abi, "gnu")
+
+        # Given
+        platform = EPDPlatform.from_epd_string("osx-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertEqual(abi, "darwin")
+
+        # Given
+        platform = EPDPlatform.from_epd_string("win-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertEqual(abi, "msvc2010")
+
+    def test_python_35(self):
+        # Given
+        implementation_version = RuntimeVersion.from_string("3.5")
+        platform = EPDPlatform.from_epd_string("rh5-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertEqual(abi, "gnu")
+
+        # Given
+        platform = EPDPlatform.from_epd_string("osx-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertEqual(abi, "darwin")
+
+        # Given
+        platform = EPDPlatform.from_epd_string("win-64").platform
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertEqual(abi, "msvc2015")
+
+    def test_no_platform(self):
+        # Given
+        implementation_version = RuntimeVersion.from_string("2.7")
+        platform = None
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertIsNone(abi)
+
+        # Given
+        implementation_version = RuntimeVersion.from_string("3.4")
+
+        # When
+        abi = _guess_platform_abi(platform, implementation_version)
+
+        # Then
+        self.assertIsNone(abi)
 
 
 class TestEggName(unittest.TestCase):

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -123,8 +123,8 @@ packages = []
         dependencies = Dependencies((), ())
 
         return EggMetadata(
-            pkg_info.name, version, platform, "cp27", "cp27m", dependencies,
-            pkg_info, pkg_info.summary
+            pkg_info.name, version, platform, "cp27", "cp27m", "gnu",
+            dependencies, pkg_info, pkg_info.summary
         )
 
     def test_reject_no_pkg_info(self):
@@ -134,7 +134,7 @@ packages = []
         dependencies = Dependencies((), ())
 
         metadata = EggMetadata("foo", version, platform, "cp27",
-                               "cp27m", dependencies, None, "")
+                               "cp27m", "gnu", dependencies, None, "")
 
         # When/Then
         with self.assertRaises(ValueError):

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ INSTALL_REQUIRES = [
     "attrs >= 15.1.0",
     "jsonschema",
     "six >= 1.9.0",
+    "stevedore < 1.10",  # newer versions don't work w/ 2.6
     "zipfile2 >= 0.0.10",
 ]
 


### PR DESCRIPTION
This adds a new field `platform_abi` in our egg metadata, thus defining a new metadata version format `1.4`.

The main rationale is to differentiate between non python packages which may have different ABIs (think Qt built w/ different versions of Visual Studio, as will be required to support python 3). For existing eggs, we can guess it from other tags (platform and python version).

@sjagoe 