### PR TITLE
BUG: fix platform_abi guess for pure python eggs.

### DIFF
--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -374,6 +374,10 @@ def _guess_platform_abi(platform, implementation):
         if implementation is None:
             # All our eggs so far have been python 2-only
             implementation = PythonImplementation.from_string("cp27")
+
+        if implementation.kind == "python":
+            return None
+
         implementation_version = "{0}.{1}".format(
             implementation.major, implementation.minor
         )

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -1100,6 +1100,41 @@ class TestEggInfo(unittest.TestCase):
             metadata._spec_depend.to_string(), r_spec_depend
         )
 
+    def test_platform_abi_no_python(self):
+        # Given
+        spec_depend = textwrap.dedent("""\
+            metadata_version = '1.3'
+
+            name = 'PythonDoc'
+            version = '2.7.3'
+            build = 1
+
+            arch = 'amd64'
+            platform = 'win32'
+            osdist = None
+            python = None
+
+            platform_tag = 'win_amd64'
+            abi_tag = 'cp27m'
+            python_tag = 'py27'
+
+            packages = [
+              'appinst',
+            ]
+        """)
+
+        egg = self._override_spec_depend(ENSTALLER_EGG, spec_depend)
+
+        # When
+        metadata = EggMetadata.from_egg(egg)
+
+        # Then
+        self.assertEqual(metadata.name, "pythondoc")
+        self.assertEqual(metadata.metadata_version, M("1.3"))
+        self.assertIs(metadata.is_strictly_supported, True)
+        self.assertIsNone(metadata.platform_abi)
+        self.assertEqual(metadata.platform_abi_string, "none")
+
     def test_support_higher_compatible_version(self):
         # Given
         spec_depend = textwrap.dedent("""\


### PR DESCRIPTION
@sjagoe that should fix the issue you were seeing w/ `PythonDoc`.

The issue was handling eggs with the tag `py27` (I wrongly assumed we did not have any such eggs yet).