### PR TITLE
FEAT: add private factory to create epd platform from pep 425 platfor…

### DIFF
--- a/okonomiyaki/platforms/tests/test_epd_platform.py
+++ b/okonomiyaki/platforms/tests/test_epd_platform.py
@@ -437,3 +437,30 @@ class TestGuessEPDPlatform(unittest.TestCase):
         # When/Then
         with self.assertRaises(OkonomiyakiError):
             EPDPlatform.from_epd_string(epd_platform_string)
+
+    def test_from_platform_tag(self):
+        # Given
+        inputs_outputs = (
+            ("linux_i686", "rh5-32"),
+            ("linux_i386", "rh5-32"),
+            ("linux_x86_64", "rh5-64"),
+            ("win32", "win-32"),
+            ("win_amd64", "win-64"),
+            ("macosx_10_6_x86_64", "osx-64"),
+            ("macosx_10_6_i386", "osx-32"),
+        )
+
+        # When/Then
+        for platform_tag, epd_string in inputs_outputs:
+            platform = EPDPlatform._from_platform_tag(platform_tag)
+            self.assertEqual(platform.short, epd_string)
+
+        # When/Then
+        with self.assertRaises(NotImplementedError):
+            EPDPlatform._from_platform_tag("openbsd_i386")
+
+        with self.assertRaises(ValueError):
+            EPDPlatform._from_platform_tag("any")
+
+        with self.assertRaises(ValueError):
+            EPDPlatform._from_platform_tag(None)


### PR DESCRIPTION
This adds `EPDPlatform._from_platform_tag`.

This is only of limited use, since platform_tag does not have enough information, but this may be used to get an EPDPlatform instance from a non-Enthought python. Mostly useful for tests in tateru.

@sjagoe 