### PR TITLE
Write metadata egg

### DIFF
--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -1068,3 +1068,41 @@ class EggMetadata(object):
             "_metadata_version": self.metadata_version,
         }
         return LegacySpecDepend(**args)
+
+    # Public methods
+    def dump(self, path):
+        """ Write the metadata to the given path as a metadata egg.
+
+        A metadata egg is a zipfile using the same structured as an egg, except
+        that it only contains metadata.
+
+        Parameters
+        ----------
+        path : str
+            The path to write the zipped metadata into.
+        """
+        with zipfile2.ZipFile(path, "w", zipfile2.ZIP_DEFLATED) as zp:
+            zp.writestr(
+                _SPEC_DEPEND_LOCATION, self.spec_depend_string.encode()
+            )
+            zp.writestr(
+                _SPEC_SUMMARY_LOCATION, self.summary.encode()
+            )
+            if self.pkg_info:
+                self.pkg_info._dump_as_zip(zp)
+
+    # Protocol implementations
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (
+                self.spec_depend_string == other.spec_depend_string and
+                self.summary == other.summary and
+                self.pkg_info == other.pkg_info
+            )
+        else:
+            raise TypeError(
+                "Only equality between EggMetadata instances is supported"
+            )
+
+    def __ne__(self, other):
+        return not self == other

--- a/okonomiyaki/file_formats/_package_info.py
+++ b/okonomiyaki/file_formats/_package_info.py
@@ -194,6 +194,12 @@ class PackageInfo(object):
 
         return s.getvalue()
 
+    def _dump_as_zip(self, zp, metadata_version_info=MAX_SUPPORTED_VERSION):
+        zp.writestr(
+            _PKG_INFO_LOCATION,
+            self.to_string(metadata_version_info).encode(PKG_INFO_ENCODING)
+        )
+
     def _write_field(self, s, name, value):
         value = '%s: %s\n' % (name, value)
         s.write(value)

--- a/okonomiyaki/file_formats/_package_info.py
+++ b/okonomiyaki/file_formats/_package_info.py
@@ -208,6 +208,26 @@ class PackageInfo(object):
         for value in values:
             self._write_field(s, name, value)
 
+    # Protocol implementations
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (
+                self.metadata_version == other.metadata_version and
+                self.to_string() == other.to_string()
+            )
+        elif other is None:
+            # We special-case None because EggMetadata.pkg_info may be None,
+            # and we want to support foo.pkg_info == foo2.pkg_info when one may
+            # be None
+            return False
+        else:
+            raise TypeError(
+                "Only equality between PackageInfo instances is supported"
+            )
+
+    def __ne__(self, other):
+        return not self == other
+
 
 def _string_to_version_info(metadata_version):
     return tuple(int(i) for i in metadata_version.split("."))

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -1478,3 +1478,67 @@ class TestEggInfo(unittest.TestCase):
             metadata.pkg_info.author_email,
             u"johannes.buchner.acad [\ufffdt] gmx.com",
         )
+
+    def test_dump_simple(self):
+        # Given
+        egg = ENSTALLER_EGG
+        r_metadata = EggMetadata.from_egg(egg)
+
+        path = os.path.join(self.tempdir, "foo.zip")
+
+        # When
+        r_metadata.dump(path)
+
+        # Then
+        metadata = EggMetadata.from_egg(path)
+        self.assertEqual(metadata, r_metadata)
+
+    def test_dump_blacklisted(self):
+        self.maxDiff = None
+
+        # Given
+        egg = FAKE_MEDIALOG_BOARDFILE_1_6_1_EGG
+        mock_sha256 = (
+            "ab9e029caf273e4a251d3686425cd4225e1b97682749acc7a82dc1fd15dbd060"
+        )
+
+        with mock.patch(
+            "okonomiyaki.file_formats._egg_info.compute_sha256",
+            return_value=mock_sha256
+        ):
+            r_metadata = EggMetadata.from_egg(egg)
+
+        path = os.path.join(self.tempdir, "foo.zip")
+
+        # When
+        r_metadata.dump(path)
+
+        # Then
+        metadata = EggMetadata.from_egg(path)
+        self.assertMultiLineEqual(
+            metadata.pkg_info.description,
+            FAKE_MEDIALOG_BOARDFILE_1_6_1_PKG_INFO
+        )
+        self.assertEqual(metadata, r_metadata)
+
+    def test_dump_blacklisted_platform(self):
+        # Given
+        egg = XZ_5_2_0_EGG
+        mock_sha256 = (
+            "ca5f2c417dd9f6354db3c2999edb441382ed11c7a034ade1839d1871a78ab2e8"
+        )
+
+        with mock.patch(
+            "okonomiyaki.file_formats._egg_info.compute_sha256",
+            return_value=mock_sha256
+        ):
+            r_metadata = EggMetadata.from_egg(egg)
+
+        path = os.path.join(self.tempdir, "foo.zip")
+
+        # When
+        r_metadata.dump(path)
+
+        # Then
+        metadata = EggMetadata.from_egg(path)
+        self.assertEqual(metadata.platform_tag, "win32")


### PR DESCRIPTION
This adds a new `EggMetadata.dump` method to write so-called metadata egg, that is egg that contain only our metadata (currently `EGG-INFO/spec/depend`, `EGG-INFO/spec/summary` and `EGG-INFO/PKG-INFO`).

The metadata are written after blacklist processing, so the metadata egg automatically gets the correct metadata.

@sjagoe 