### PR TITLE
FEAT: add basic CLI for python -m okonomiyaki.

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,3 +2,4 @@ coverage
 flake8
 haas
 mock<1.1
+testfixtures

--- a/okonomiyaki/__main__.py
+++ b/okonomiyaki/__main__.py
@@ -1,0 +1,5 @@
+from ._cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/okonomiyaki/_cli/__init__.py
+++ b/okonomiyaki/_cli/__init__.py
@@ -1,0 +1,79 @@
+import argparse
+import sys
+
+from ..file_formats import EggMetadata
+from ..versions import MetadataVersion
+
+
+def pkg_info(ns):
+    metadata = EggMetadata._from_egg(ns.path, ns.sha256)
+    if metadata.pkg_info is None:
+        print("No PKG-INFO")
+        sys.exit(-1)
+    else:
+        print(metadata.pkg_info.to_string().rstrip())
+
+
+def spec_depend(ns):
+    metadata = EggMetadata._from_egg(ns.path, ns.sha256)
+    if ns.metadata_version is not None:
+        metadata.metadata_version = MetadataVersion.from_string(
+            ns.metadata_version
+        )
+    print(metadata.spec_depend_string.rstrip())
+
+
+def summary(ns):
+    metadata = EggMetadata._from_egg(ns.path, ns.sha256)
+    print(metadata.summary.rstrip())
+
+
+def main(argv=None):
+    argv = argv or sys.argv[1:]
+
+    p = argparse.ArgumentParser(
+        description="description: query Enthought egg metadata."
+    )
+    subparsers = p.add_subparsers()
+
+    spec_depend_p = subparsers.add_parser(
+        "spec-depend",
+        help="Show spec/depend metadata"
+    )
+    spec_depend_p.add_argument("path")
+    spec_depend_p.add_argument(
+        "--metadata-version",
+        help="If given, the metadata version to use to output the spec/depend"
+    )
+    spec_depend_p.add_argument(
+        "--sha256",
+        help="Inject the given sha256 instead of calculating it from the "
+             "given egg"
+    )
+    spec_depend_p.set_defaults(func=spec_depend)
+
+    pkg_info_p = subparsers.add_parser(
+        "pkg-info",
+        help="Show PKG-INFO metadata"
+    )
+    pkg_info_p.add_argument("path")
+    pkg_info_p.add_argument(
+        "--sha256",
+        help="Inject the given sha256 instead of calculating it from the "
+             "given egg"
+    )
+    pkg_info_p.set_defaults(func=pkg_info)
+
+    summary_p = subparsers.add_parser(
+        "summary", help="Show spec/summary"
+    )
+    summary_p.add_argument("path")
+    summary_p.add_argument(
+        "--sha256",
+        help="Inject the given sha256 instead of calculating it from the "
+             "given egg"
+    )
+    summary_p.set_defaults(func=summary)
+
+    ns = p.parse_args(argv)
+    ns.func(ns)

--- a/okonomiyaki/_cli/__init__.py
+++ b/okonomiyaki/_cli/__init__.py
@@ -1,6 +1,8 @@
 import argparse
 import sys
 
+import zipfile2
+
 from ..file_formats import EggMetadata
 from ..versions import MetadataVersion
 
@@ -21,6 +23,14 @@ def spec_depend(ns):
             ns.metadata_version
         )
     print(metadata.spec_depend_string.rstrip())
+
+
+def show_index(ns):
+    with zipfile2.ZipFile(ns.path) as zp:
+        entries = sorted(zp.namelist())
+
+    for entry in entries:
+        print(entry)
 
 
 def summary(ns):
@@ -74,6 +84,17 @@ def main(argv=None):
              "given egg"
     )
     summary_p.set_defaults(func=summary)
+
+    index_p = subparsers.add_parser(
+        "show-index", help="Show the egg content"
+    )
+    index_p.add_argument("path")
+    index_p.add_argument(
+        "--sha256",
+        help="Inject the given sha256 instead of calculating it from the "
+             "given egg"
+    )
+    index_p.set_defaults(func=show_index)
 
     ns = p.parse_args(argv)
     ns.func(ns)

--- a/okonomiyaki/_cli/tests/test_cli.py
+++ b/okonomiyaki/_cli/tests/test_cli.py
@@ -1,0 +1,96 @@
+import os.path
+import shutil
+import tempfile
+import textwrap
+import unittest
+
+import testfixtures
+
+from okonomiyaki.file_formats import EggMetadata, PackageInfo
+from okonomiyaki.utils.test_data import NOSE_1_3_4_RH5_X86_64
+from okonomiyaki._cli import main
+
+
+class TestMain(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_spec_depend(self):
+        # Given
+        egg = NOSE_1_3_4_RH5_X86_64
+
+        r_output = textwrap.dedent("""\
+        metadata_version = '1.3'
+        name = 'nose'
+        version = '1.3.4'
+        build = 1
+        
+        arch = 'amd64'
+        platform = 'linux2'
+        osdist = 'RedHat_5'
+        python = '2.7'
+        
+        python_tag = 'cp27'
+        abi_tag = 'cp27m'
+        platform_tag = 'linux_x86_64'
+        
+        packages = []
+        """)
+
+        # When
+        with testfixtures.OutputCapture() as capture:
+            main(["spec-depend", egg])
+
+        # Then
+        self.assertMultiLineEqual(capture.output.getvalue(), r_output)
+
+    def test_pkg_info(self):
+        # Given
+        egg = NOSE_1_3_4_RH5_X86_64
+
+        r_output = PackageInfo.from_egg(egg).to_string()
+
+        # When
+        with testfixtures.OutputCapture() as capture:
+            main(["pkg-info", egg])
+
+        # Then
+        self.assertMultiLineEqual(capture.output.getvalue(), r_output)
+
+    def test_summary(self):
+        # Given
+        egg = NOSE_1_3_4_RH5_X86_64
+
+        r_output = textwrap.dedent("""\
+        Extends the Python Unittest module with additional disocvery and running
+        options
+        """)
+
+        # When
+        with testfixtures.OutputCapture() as capture:
+            main(["summary", egg])
+
+        # Then
+        self.assertMultiLineEqual(capture.output.getvalue(), r_output)
+
+    def test_no_pkg_info(self):
+        # Given
+        path = os.path.join(
+            self.tempdir, os.path.basename(NOSE_1_3_4_RH5_X86_64)
+        )
+        m = EggMetadata.from_egg(NOSE_1_3_4_RH5_X86_64)
+        m.pkg_info = None
+        m.dump(path)
+
+        # When/Then
+        with testfixtures.OutputCapture() as capture:
+            with self.assertRaises(SystemExit) as exc:
+                main(["pkg-info", path])
+            self.assertEqual(exc.exception.code, -1)
+
+        capture.compare("No PKG-INFO")

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,8 @@ def main():
           packages=["okonomiyaki",
                     "okonomiyaki.bundled",
                     "okonomiyaki.bundled.traitlets",
+                    "okonomiyaki._cli",
+                    "okonomiyaki._cli.tests",
                     "okonomiyaki.file_formats",
                     "okonomiyaki.file_formats.tests",
                     "okonomiyaki.file_formats._blacklist",


### PR DESCRIPTION
Add support for `python -m okonomiyaki`. This simple CLI has 3 commands:

* spec-depend: see the `spec/depend` file (after blacklisting processing)
* summary: print the summary (in `spec/summary`)
* pkg-info: print the content of `PKG-INFO`
* show-index: print the sorted archive content

@sjagoe 