### PR TITLE
Fix test new pypy

### DIFF
--- a/okonomiyaki/_cli/tests/test_cli.py
+++ b/okonomiyaki/_cli/tests/test_cli.py
@@ -1,14 +1,19 @@
 import os.path
 import shutil
+import sys
 import tempfile
 import textwrap
-import unittest
 
 import testfixtures
 
 from okonomiyaki.file_formats import EggMetadata, PackageInfo
 from okonomiyaki.utils.test_data import NOSE_1_3_4_RH5_X86_64
 from okonomiyaki._cli import main
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestMain(unittest.TestCase):
@@ -91,6 +96,10 @@ class TestMain(unittest.TestCase):
         with testfixtures.OutputCapture() as capture:
             with self.assertRaises(SystemExit) as exc:
                 main(["pkg-info", path])
-            self.assertEqual(exc.exception.code, -1)
+            if sys.version_info < (2, 7):
+                code = exc.exception
+            else:
+                code = exc.exception.code
+            self.assertEqual(code, -1)
 
         capture.compare("No PKG-INFO")

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -8,7 +8,7 @@ import zipfile2
 
 import mock
 
-if sys.version_info[:2] < (2, 7):
+if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest

--- a/okonomiyaki/file_formats/tests/test__package_info.py
+++ b/okonomiyaki/file_formats/tests/test__package_info.py
@@ -9,7 +9,7 @@ import mock
 from .._blacklist.pkg_info_data import PYSIDE_1_1_0_PKG_INFO
 from .._package_info import PKG_INFO_ENCODING, _PKG_INFO_LOCATION, PackageInfo
 
-if sys.version_info[:2] < (2, 7):
+if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -7,7 +7,7 @@ import tempfile
 import textwrap
 import zipfile2
 
-if sys.version_info[:2] < (2, 7):
+if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest

--- a/okonomiyaki/file_formats/tests/test_setuptools_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_setuptools_file_format.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info[:2] < (2, 7):
+if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest

--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -194,7 +194,7 @@ class EPDPlatform(object):
                     epd_string = "win_" + str(Arch.from_name(arch_string))
             else:
                 raise NotImplementedError(
-                    "Unsupported platform '{}'".format(platform_tag)
+                    "Unsupported platform '{0}'".format(platform_tag)
                 )
 
             return cls.from_epd_string(epd_string)

--- a/okonomiyaki/platforms/tests/test__arch.py
+++ b/okonomiyaki/platforms/tests/test__arch.py
@@ -1,10 +1,15 @@
-import unittest
+import sys
 
 from ...errors import OkonomiyakiError
 from .._arch import Arch
 
 from .common import (mock_machine_armv71, mock_x86, mock_x86_64,
                      mock_x86_on_x86_64)
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestArch(unittest.TestCase):

--- a/okonomiyaki/platforms/tests/test_abi.py
+++ b/okonomiyaki/platforms/tests/test_abi.py
@@ -1,7 +1,12 @@
-import unittest
+import sys
 
 from ...errors import OkonomiyakiError
 from ..abi import default_abi
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestDefaultABI(unittest.TestCase):

--- a/okonomiyaki/platforms/tests/test_epd_platform.py
+++ b/okonomiyaki/platforms/tests/test_epd_platform.py
@@ -1,5 +1,5 @@
 import mock
-import unittest
+import sys
 
 from ...errors import OkonomiyakiError
 
@@ -16,6 +16,11 @@ from .common import (
     mock_centos_6_3, mock_darwin, mock_machine_x86, mock_machine_x86_64,
     mock_solaris, mock_ubuntu_raring, mock_windows, mock_x86, mock_x86_64
 )
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestEPDPlatform(unittest.TestCase):
@@ -139,7 +144,7 @@ class TestEPDPlatform(unittest.TestCase):
     def test_epd_platform_from_string_new_arch(self):
         def old_to_new_name(epd_platform_string):
             left, right = epd_platform_string.split("-")
-            return "{}-{}".format(left, {"32": X86, "64": X86_64}[right])
+            return "{0}-{1}".format(left, {"32": X86, "64": X86_64}[right])
 
         # Given
         name_to_platform = {}

--- a/okonomiyaki/platforms/tests/test_platform.py
+++ b/okonomiyaki/platforms/tests/test_platform.py
@@ -1,4 +1,4 @@
-import unittest
+import sys
 
 from ...errors import OkonomiyakiError
 from ..epd_platform import EPDPlatform
@@ -9,6 +9,11 @@ from .common import (mock_machine_armv71, mock_x86, mock_x86_64,
 from .common import (mock_architecture_64bit, mock_centos_3_5, mock_centos_5_8,
                      mock_centos_6_3, mock_osx_10_7, mock_solaris,
                      mock_ubuntu_raring, mock_windows_7)
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestPlatformRunningPython(unittest.TestCase):

--- a/okonomiyaki/platforms/tests/test_platform_filters.py
+++ b/okonomiyaki/platforms/tests/test_platform_filters.py
@@ -1,11 +1,17 @@
 from __future__ import absolute_import
 
-import unittest
+import sys
 
 from .._arch import Arch
 from ..epd_platform import EPDPlatform
 from ..platform import OSKind, NameKind, FamilyKind, Platform
 from ..platform_filters import PlatformFilter, PlatformLabel, PlatformLiteral
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
 
 LABEL_WINDOWS_ANY = PlatformLabel()
 LABEL_WINDOWS_ANY.os_kind = OSKind.windows

--- a/okonomiyaki/platforms/tests/test_python_implementation.py
+++ b/okonomiyaki/platforms/tests/test_python_implementation.py
@@ -1,9 +1,14 @@
-import unittest
+import sys
 
 import mock
 
 from ..python_implementation import PythonImplementation
 from ...errors import InvalidMetadataField
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestPythonImplementation(unittest.TestCase):

--- a/okonomiyaki/runtimes/tests/test_runtime.py
+++ b/okonomiyaki/runtimes/tests/test_runtime.py
@@ -39,6 +39,10 @@ class TestPythonRuntime(unittest.TestCase):
                 os.path.realpath(NORM_EXECUTABLE)
             )
 
+    @unittest.skipIf(
+        hasattr(sys, "pypy_version_info"),
+        "This test is only supported on cpython"
+    )
     def test_from_prefix_and_platform(self):
         # Given
         prefix = u"/usr/local"

--- a/okonomiyaki/runtimes/tests/test_runtime.py
+++ b/okonomiyaki/runtimes/tests/test_runtime.py
@@ -1,11 +1,15 @@
 import os.path
 import sys
-import unittest
 
 from okonomiyaki.platforms import EPDPlatform
 from okonomiyaki.versions import RuntimeVersion
 
 from ..runtime import PythonRuntime
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 NORM_EXEC_PREFIX = os.path.normpath(sys.exec_prefix)

--- a/okonomiyaki/runtimes/tests/test_runtime_info.py
+++ b/okonomiyaki/runtimes/tests/test_runtime_info.py
@@ -1,6 +1,5 @@
 import os.path
 import sys
-import unittest
 
 from okonomiyaki.utils.test_data import (
     JULIA_DEFAULT_0_3_11_RH5_X86_64, JULIA_DEFAULT_0_3_11_WIN_X86_64,
@@ -8,6 +7,11 @@ from okonomiyaki.utils.test_data import (
 )
 from ..runtime_metadata import IRuntimeMetadata
 from ..runtime_info import IRuntimeInfo
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestPythonRuntimeInfoV1(unittest.TestCase):

--- a/okonomiyaki/runtimes/tests/test_runtime_metadata.py
+++ b/okonomiyaki/runtimes/tests/test_runtime_metadata.py
@@ -1,6 +1,6 @@
 import os.path
 import shutil
-import unittest
+import sys
 
 import zipfile2
 
@@ -18,6 +18,11 @@ from ..runtime_metadata import (
     JuliaRuntimeMetadataV1, PythonRuntimeMetadataV1, RuntimeVersion,
     is_runtime_path_valid, runtime_metadata_factory
 )
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestPythonMetadataV1(unittest.TestCase):
@@ -225,7 +230,8 @@ class TestRuntimeMetadataFactory(unittest.TestCase):
         # When/Then
         with tempdir() as d:
             target = os.path.join(d, os.path.basename(path))
-            with zipfile2.ZipFile(target, "w"):
-                pass
+            # One needs to add an archive for the zipfile to be valid on 2.6.
+            with zipfile2.ZipFile(target, "w") as zp:
+                zp.writestr("dummy", b"dummy data")
             with self.assertRaises(MissingMetadata):
                 runtime_metadata_factory(target)

--- a/okonomiyaki/utils/tests/test_main.py
+++ b/okonomiyaki/utils/tests/test_main.py
@@ -1,11 +1,15 @@
 import io
 import os.path
 import shutil
+import sys
 import tempfile
-import unittest
-
 
 from .. import compute_sha256
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestSha256(unittest.TestCase):

--- a/okonomiyaki/utils/tests/test_misc.py
+++ b/okonomiyaki/utils/tests/test_misc.py
@@ -1,9 +1,14 @@
+import sys
 import textwrap
-import unittest
 
 from ...errors import OkonomiyakiError
 from ..misc import parse_assignments, substitute_variables
 from ..py3compat import StringIO
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestParseAssignments(unittest.TestCase):

--- a/okonomiyaki/versions/tests/test_enpkg_version.py
+++ b/okonomiyaki/versions/tests/test_enpkg_version.py
@@ -1,10 +1,14 @@
-import unittest
-
+import sys
 
 from okonomiyaki.errors import InvalidEnpkgVersion
 
 from ..enpkg import EnpkgVersion
 from ..pep386_workaround import PEP386WorkaroundVersion
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestEnpkgVersionParsing(unittest.TestCase):

--- a/okonomiyaki/versions/tests/test_metadata_version.py
+++ b/okonomiyaki/versions/tests/test_metadata_version.py
@@ -1,8 +1,13 @@
-import unittest
+import sys
 
 from okonomiyaki.errors import InvalidMetadataVersion
 
 from .. import MetadataVersion
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestMetadataVersion(unittest.TestCase):

--- a/okonomiyaki/versions/tests/test_pep386_workaround.py
+++ b/okonomiyaki/versions/tests/test_pep386_workaround.py
@@ -1,6 +1,11 @@
-import unittest
+import sys
 
 from ..pep386_workaround import PEP386WorkaroundVersion
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestPEP386Workaround(unittest.TestCase):

--- a/okonomiyaki/versions/tests/test_pep440.py
+++ b/okonomiyaki/versions/tests/test_pep440.py
@@ -1,8 +1,13 @@
-import unittest
+import sys
 
 from okonomiyaki.errors import InvalidPEP440Version
 
 from ..pep440 import _MIN, _MAX, PEP440Version
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 V = PEP440Version.from_string

--- a/okonomiyaki/versions/tests/test_runtime_version.py
+++ b/okonomiyaki/versions/tests/test_runtime_version.py
@@ -1,6 +1,11 @@
-import unittest
+import sys
 
 from ..runtime_version import RuntimeVersion
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 V = RuntimeVersion.from_string

--- a/okonomiyaki/versions/tests/test_semver.py
+++ b/okonomiyaki/versions/tests/test_semver.py
@@ -1,10 +1,15 @@
 import re
-import unittest
+import sys
 
 from okonomiyaki.errors import InvalidSemanticVersion
 
 from ..enpkg import EnpkgVersion
 from ..semver import SemanticVersion, _PrereleaseParts
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestSemanticVersion(unittest.TestCase):


### PR DESCRIPTION
Fix tests when run on recent pypy `5.x`, and also uses `unittest2` consistently for 2.6 + 2.6 fixes.

@noraderam 