### PR TITLE
ENH: speed-up EggMetadata parsing from egg.

### DIFF
--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -664,6 +664,14 @@ class EggMetadata(object):
     well.
     """
 
+    @staticmethod
+    def _may_be_in_blacklist(path):
+        return (
+            may_be_in_platform_blacklist(path)
+            or may_be_in_pkg_info_blacklist(path)
+            or may_be_in_python_tag_blacklist(path)
+        )
+
     @classmethod
     def from_egg(cls, path_or_file, strict=True):
         """ Create a EggMetadata instance from an existing Enthought egg.
@@ -680,11 +688,7 @@ class EggMetadata(object):
         """
         sha256 = None
         if isinstance(path_or_file, string_types):
-            if (
-                may_be_in_platform_blacklist(path_or_file)
-                or may_be_in_pkg_info_blacklist(path_or_file)
-                or may_be_in_python_tag_blacklist(path_or_file)
-            ):
+            if cls._may_be_in_blacklist(path_or_file):
                 sha256 = compute_sha256(path_or_file)
         else:
             with _keep_position(path_or_file.fp):

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -703,20 +703,24 @@ class EggMetadata(object):
                 summary = b""
             return summary.decode("utf8")
 
-        spec_depend = LegacySpecDepend._from_egg(path_or_file, sha256)
+        def _compute_all_metadata(fp):
+            summary = _read_summary(fp)
+            pkg_info_data = _read_pkg_info(fp)
+
+            if pkg_info_data is None:
+                pkg_info = None
+            else:
+                pkg_info = PackageInfo._from_egg(fp, sha256, strict)
+
+            spec_depend = LegacySpecDepend._from_egg(fp, sha256)
+
+            return summary, pkg_info, spec_depend
 
         if isinstance(path_or_file, string_types):
-            with zipfile2.ZipFile(path_or_file) as fp:
-                summary = _read_summary(fp)
-                pkg_info_data = _read_pkg_info(fp)
+            with zipfile2.ZipFile(path_or_file) as zp:
+                summary, pkg_info, spec_depend = _compute_all_metadata(zp)
         else:
-            summary = _read_summary(path_or_file)
-            pkg_info_data = _read_pkg_info(path_or_file)
-
-        if pkg_info_data is None:
-            pkg_info = None
-        else:
-            pkg_info = PackageInfo._from_egg(path_or_file, sha256, strict)
+            summary, pkg_info, spec_depend = _compute_all_metadata(path_or_file)
 
         return cls._from_spec_depend(spec_depend, pkg_info, summary)
 


### PR DESCRIPTION
We were calling `ZipFile` 3 times, which is quite expensive for eggs with a large number of archives.

With this fix, parsing metadata of an with a large number of archives ( e.g. VTK) is only 5-10 % slower than just one call to ZipFile (compared to 200 % slower before).

Close #195 