### PR TITLE
MAINT: put stevedore version constraint in dev_requirements, where it belongs

### DIFF
--- a/dev_requirements2.txt
+++ b/dev_requirements2.txt
@@ -1,2 +1,3 @@
+stevedore < 1.10  # newer versions don't work w/ 2.6
 -r dev_requirements.txt
 unittest2

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ INSTALL_REQUIRES = [
     "attrs >= 15.2.0",
     "jsonschema >= 2.5.1",
     "six >= 1.9.0",
-    "stevedore < 1.10",  # newer versions don't work w/ 2.6
     "zipfile2 >= 0.0.12",
 ]
 


### PR DESCRIPTION
Stevedore is only needed for testing (through haas), so we should put
the constraint for python 2.6 compatibility in dev/test requirements,
not runtime dependencies.

Fix #208 