### PR TITLE
ENH: lazily parse PKG-INFO.

### DIFF
--- a/okonomiyaki/_cli/tests/test_cli.py
+++ b/okonomiyaki/_cli/tests/test_cli.py
@@ -89,7 +89,7 @@ class TestMain(unittest.TestCase):
             self.tempdir, os.path.basename(NOSE_1_3_4_RH5_X86_64)
         )
         m = EggMetadata.from_egg(NOSE_1_3_4_RH5_X86_64)
-        m.pkg_info = None
+        m._pkg_info = None
         m.dump(path)
 
         # When/Then

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -825,9 +825,10 @@ class EggMetadata(object):
         dependencies: Dependencies
             A Dependencies instance.
         pkg_info: PackageInfo or str or None
-            Instance modeling the PKG-INFO content of the egg. If a string, is
-            lazily parsed into a PackageInfo when pkg_info is accessed for the
-            first time.
+            Instance modeling the PKG-INFO content of the egg. If a string is
+            passed, it is assumed to be the PKG-INFO content, and is lazily
+            parsed into a PackageInfo when pkg_info is accessed for the first
+            time.
         summary: str
             The summary. Models the string in EGG-INFO/spec/summary. May
             be empty.

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -28,7 +28,9 @@ from ._blacklist import (
     may_be_in_platform_blacklist, may_be_in_python_tag_blacklist,
     may_be_in_pkg_info_blacklist
 )
-from ._package_info import PackageInfo, _keep_position, _read_pkg_info
+from ._package_info import (
+    PackageInfo, _convert_if_needed, _keep_position, _read_pkg_info
+)
 
 
 _EGG_NAME_RE = re.compile("""
@@ -722,23 +724,26 @@ class EggMetadata(object):
         def _compute_all_metadata(fp):
             summary = _read_summary(fp)
             pkg_info_data = _read_pkg_info(fp)
-
             if pkg_info_data is None:
-                pkg_info = None
+                pkg_info_string = None
             else:
-                pkg_info = PackageInfo._from_egg(fp, sha256, strict)
+                pkg_info_string = _convert_if_needed(
+                    pkg_info_data, sha256, strict
+                )
 
             spec_depend = LegacySpecDepend._from_egg(fp, sha256)
 
-            return summary, pkg_info, spec_depend
+            return summary, pkg_info_string, spec_depend
 
         if isinstance(path_or_file, string_types):
             with zipfile2.ZipFile(path_or_file) as zp:
-                summary, pkg_info, spec_depend = _compute_all_metadata(zp)
+                summary, pkg_info_string, spec_depend = _compute_all_metadata(zp)
         else:
-            summary, pkg_info, spec_depend = _compute_all_metadata(path_or_file)
+            summary, pkg_info_string, spec_depend = _compute_all_metadata(
+                path_or_file
+            )
 
-        return cls._from_spec_depend(spec_depend, pkg_info, summary)
+        return cls._from_spec_depend(spec_depend, pkg_info_string, summary)
 
     @classmethod
     def _from_spec_depend(cls, spec_depend, pkg_info, summary,
@@ -819,8 +824,10 @@ class EggMetadata(object):
             The platform abi, e.g. 'msvc2008', 'gnu', etc. May be None.
         dependencies: Dependencies
             A Dependencies instance.
-        pkg_info: PackageInfo or None
-            Instance modeling the PKG-INFO content of the egg.
+        pkg_info: PackageInfo or str or None
+            Instance modeling the PKG-INFO content of the egg. If a string, is
+            lazily converted parsed into a PackageInfo when pkg_info is
+            accessed.
         summary: str
             The summary. Models the string in EGG-INFO/spec/summary. May
             be empty.
@@ -857,7 +864,7 @@ class EggMetadata(object):
         self.metadata_version = metadata_version or _METADATA_DEFAULT_VERSION
         """ The version format of the underlying metadata."""
 
-        self.pkg_info = pkg_info
+        self._pkg_info = pkg_info
         """ A PackageInfo instance modeling the underlying PKG-INFO. May
         be None for eggs without an PKG-INFO file."""
 
@@ -914,6 +921,13 @@ class EggMetadata(object):
     def name(self):
         """ The package name."""
         return self._raw_name.lower().replace("-", "_")
+
+    @property
+    def pkg_info(self):
+        if isinstance(self._pkg_info, six.string_types):
+            self._pkg_info = PackageInfo.from_string(self._pkg_info)
+
+        return self._pkg_info
 
     @property
     def platform_abi_tag(self):

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -826,8 +826,8 @@ class EggMetadata(object):
             A Dependencies instance.
         pkg_info: PackageInfo or str or None
             Instance modeling the PKG-INFO content of the egg. If a string, is
-            lazily converted parsed into a PackageInfo when pkg_info is
-            accessed.
+            lazily parsed into a PackageInfo when pkg_info is accessed for the
+            first time.
         summary: str
             The summary. Models the string in EGG-INFO/spec/summary. May
             be empty.


### PR DESCRIPTION
There are many cases where we want an EggMetadata instance for a given
egg but are not interested in the PKG-INFO content. This commit allows
EggMetadata.pkg_info to be lazily loaded.

This helps making `edm list` 30 % faster.

@johntyree 