### PR TITLE
Backport #229 Add support for CPython 3.6

### DIFF
--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -708,6 +708,35 @@ class TestGuessPlatformAbi(unittest.TestCase):
         # Then
         self.assertEqual(abi, "msvc2015")
 
+    def test_python_36(self):
+        # Given
+        platform = EPDPlatform.from_epd_string("rh5-64")
+        python_tag = "cp36"
+
+        # When
+        abi = _guess_platform_abi(platform, python_tag)
+
+        # Then
+        self.assertEqual(abi, "gnu")
+
+        # Given
+        platform = EPDPlatform.from_epd_string("osx-64")
+
+        # When
+        abi = _guess_platform_abi(platform, python_tag)
+
+        # Then
+        self.assertEqual(abi, "darwin")
+
+        # Given
+        platform = EPDPlatform.from_epd_string("win-64")
+
+        # When
+        abi = _guess_platform_abi(platform, python_tag)
+
+        # Then
+        self.assertEqual(abi, "msvc2015")
+
     def test_no_platform(self):
         # Given
         platform = None

--- a/okonomiyaki/platforms/abi.py
+++ b/okonomiyaki/platforms/abi.py
@@ -44,7 +44,7 @@ def _default_cpython_abi(platform, implementation_version):
                 abi = u"msvc2008"
             elif implementation_version.minor <= 4:
                 abi = u"msvc2010"
-            elif implementation_version.minor == 5:
+            elif implementation_version.minor <= 6:
                 abi = u"msvc2015"
 
         if abi is None:

--- a/okonomiyaki/platforms/tests/test_abi.py
+++ b/okonomiyaki/platforms/tests/test_abi.py
@@ -18,6 +18,7 @@ class TestDefaultABI(unittest.TestCase):
             (("win_x86", "cpython", "2.7.10+1"), u"msvc2008"),
             (("win_x86", "cpython", "3.4.3+1"), u"msvc2010"),
             (("win_x86", "cpython", "3.5.0+1"), u"msvc2015"),
+            (("win_x86", "cpython", "3.6.0+1"), u"msvc2015"),
             (("osx_x86_64", "pypy", "2.6.1+1"), u"darwin"),
             (("rh5_x86_64", "pypy", "2.6.1+1"), u"gnu"),
             (("win_x86", "pypy", "2.6.1+1"), u"msvc2008"),
@@ -34,7 +35,7 @@ class TestDefaultABI(unittest.TestCase):
     def test_non_supported(self):
         # Given
         args = (
-            ("win_x86", "cpython", "3.6.0+1"),
+            ("win_x86", "cpython", "3.7.0+1"),
             ("win_x86", "pypy", "4.1.0+1"),
             ("rh5_x86_64", "r", "3.0.0+1"),
         )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ IS_RELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 INSTALL_REQUIRES = [
-    "attrs >= 16.0.0",
+    "attrs < 16.1.0",  # Needed to support Python 2.6
     "jsonschema >= 2.5.1",
     "six >= 1.9.0",
     "zipfile2 >= 0.0.12",


### PR DESCRIPTION
How does this look @cournape? 

Add support for CPython 3.6
(cherry picked from commit 6cf78196db82c285d3d3fb7629774f0e2c5badc1)