### PR TITLE
MAINT: fix author_* entries in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,8 +124,8 @@ def main():
     }
 
     setup(name="okonomiyaki",
-          author="David Cournapeau",
-          author_email="David Cournapeau",
+          author="Enthought, Inc.",
+          author_email="info@enthought.com",
           packages=["okonomiyaki",
                     "okonomiyaki._cli",
                     "okonomiyaki._cli.tests",


### PR DESCRIPTION
We fix both `author` and `author_email`. `twine` now validates email when uploading eggs/sdists, causing failures w/ our current `setup.py`.