### PR TITLE
ENH: fix permissions for egg metadata written through writestr.

### DIFF
--- a/okonomiyaki/file_formats/egg.py
+++ b/okonomiyaki/file_formats/egg.py
@@ -74,13 +74,12 @@ class _EggBuilderNoPkgInfo(object):
                 "Invalid member name for data: '{}'".format(archive_name)
             )
 
-        if not isinstance(archive_name, zipfile.ZipInfo):
-            zinfo = zipfile.ZipInfo(
-                filename=archive_name,
-                date_time=time.localtime(time.time())[:6]
-            )
-            zinfo.compress_type = self._fp.compression
-            zinfo.external_attr = chmod << 16
+        zinfo = zipfile.ZipInfo(
+            filename=archive_name,
+            date_time=time.localtime(time.time())[:6]
+        )
+        zinfo.compress_type = self._fp.compression
+        zinfo.external_attr = chmod << 16
         self._fp.writestr(zinfo, data)
 
     def add_tree(self, directory, archive_prefix=""):

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -313,7 +313,10 @@ packages = []
             pkg_info = os.path.join(r_prefix, archive)
             self.assertTrue(os.path.exists(pkg_info))
             perms = stat.S_IMODE(os.stat(pkg_info).st_mode)
-            self.assertEqual(perms, 0o644)
+            if sys.platform == "win32":
+                self.assertEqual(perms, 0o666)
+            else:
+                self.assertEqual(perms, 0o644)
 
 
 class TestEggRewriter(unittest.TestCase):

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -318,6 +318,16 @@ packages = []
             else:
                 self.assertEqual(perms, 0o644)
 
+    def test_add_data(self):
+        # Given
+        metadata = self._create_fake_metadata()
+
+        # When/Then
+        # Ensure we don't create "directories" w/ data
+        with self.assertRaises(ValueError):
+            with EggBuilder(metadata, cwd=self.d) as fp:
+                fp.add_data(b"data", "EGG-INFO/")
+
 
 class TestEggRewriter(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This will fix eggs built by tateru which had `PKG-INFO` to be readable by the owner only (on Unix).