### PR TITLE
Merge pull request #249 from enthought/bug/fix-metadata-permissions

### DIFF
--- a/okonomiyaki/file_formats/egg.py
+++ b/okonomiyaki/file_formats/egg.py
@@ -3,6 +3,7 @@ import os.path
 import re
 import shutil
 import tempfile
+import time
 import zipfile
 
 import zipfile2
@@ -66,9 +67,20 @@ class _EggBuilderNoPkgInfo(object):
         """ Add the given file to the egg, under the given archive name."""
         self._fp.write(path, archive_name)
 
-    def add_data(self, data, archive_name):
+    def add_data(self, data, archive_name, chmod=0o644):
         """ Write the given data as the given archive name."""
-        self._fp.writestr(archive_name, data)
+        if archive_name[-1] == "/":
+            raise ValueError(
+                "Invalid member name for data: '{}'".format(archive_name)
+            )
+
+        zinfo = zipfile.ZipInfo(
+            filename=archive_name,
+            date_time=time.localtime(time.time())[:6]
+        )
+        zinfo.compress_type = self._fp.compression
+        zinfo.external_attr = chmod << 16
+        self._fp.writestr(zinfo, data)
 
     def add_tree(self, directory, archive_prefix=""):
         """
@@ -94,16 +106,18 @@ class _EggBuilderNoPkgInfo(object):
 
     def _write_spec_depend(self):
         spec_depend_string = self._egg_metadata.spec_depend_string
-        self._fp.writestr(_SPEC_DEPEND_LOCATION,
-                          spec_depend_string.encode("ascii"))
+        self.add_data(
+            spec_depend_string.encode("ascii"), _SPEC_DEPEND_LOCATION)
 
     def _write_spec_summary(self):
-        self._fp.writestr(_SPEC_SUMMARY_LOCATION,
-                          self._egg_metadata.summary.encode("utf8"))
+        self.add_data(
+            self._egg_metadata.summary.encode("utf8"),
+            _SPEC_SUMMARY_LOCATION,
+        )
 
     def _write_pkg_info(self):
         data = self._egg_metadata.pkg_info.to_string()
-        self._fp.writestr(_PKG_INFO_LOCATION, data.encode("utf8"))
+        self.add_data(data.encode("utf8"), _PKG_INFO_LOCATION)
 
 
 class EggBuilder(_EggBuilderNoPkgInfo):

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -2,6 +2,7 @@
 import os
 import os.path
 import shutil
+import stat
 import sys
 import tempfile
 import textwrap
@@ -285,6 +286,47 @@ packages = []
 
         with zipfile2.ZipFile(egg_path, "r") as fp:
             self.assertEqual(set(fp.namelist()), set(r_files))
+
+    def test_files_are_readable(self):
+        # Given
+        metadata = self._create_fake_metadata()
+        r_prefix = os.path.join(self.d, "prefix")
+
+        # When
+        with EggBuilder(metadata, cwd=self.d) as fp:
+            pass
+
+        egg_path = os.path.join(self.d, "Qt_debug-4.8.6-1.egg")
+
+        with zipfile2.ZipFile(egg_path, "r") as fp:
+            fp.extractall(
+                r_prefix, preserve_permissions=zipfile2.PERMS_PRESERVE_SAFE
+            )
+
+        # Then
+        # Files are readable for everybody
+        for archive in (
+            "EGG-INFO/PKG-INFO",
+            "EGG-INFO/spec/depend",
+            "EGG-INFO/spec/summary",
+        ):
+            pkg_info = os.path.join(r_prefix, archive)
+            self.assertTrue(os.path.exists(pkg_info))
+            perms = stat.S_IMODE(os.stat(pkg_info).st_mode)
+            if sys.platform == "win32":
+                self.assertEqual(perms, 0o666)
+            else:
+                self.assertEqual(perms, 0o644)
+
+    def test_add_data(self):
+        # Given
+        metadata = self._create_fake_metadata()
+
+        # When/Then
+        # Ensure we don't create "directories" w/ data
+        with self.assertRaises(ValueError):
+            with EggBuilder(metadata, cwd=self.d) as fp:
+                fp.add_data(b"data", "EGG-INFO/")
 
 
 class TestEggRewriter(unittest.TestCase):


### PR DESCRIPTION
ENH: fix permissions for egg metadata written through writestr.
(cherry picked from commit 5087f9c8ec82ac45711e20083ad846d6d85880fe)