### PR TITLE
Merge pull request #253 from enthought/maint/fix-platform-parsing

### DIFF
--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -56,9 +56,11 @@ EPD_PLATFORM_SHORT_NAMES = (
 VALID_PLATFORMS_FILTER = PLATFORM_NAMES + ("all", "rh",)
 
 _EPD_PLATFORM_STRING_RE = re.compile("""
+    ^
     (?P<os>[^-_]+)
     [_-]
     (?P<arch>[^-]+)
+    $
     """, flags=re.VERBOSE)
 
 _LINUX_TAG_R = re.compile("^linux_(?P<arch>\S+)$")

--- a/okonomiyaki/platforms/tests/test_epd_platform.py
+++ b/okonomiyaki/platforms/tests/test_epd_platform.py
@@ -61,6 +61,11 @@ class TestEPDPlatform(unittest.TestCase):
             platform = EPDPlatform.from_string(platform_string)
             self.assertIsInstance(six.text_type(platform), six.text_type)
 
+    def test_over_complete_strings(self):
+        # When/Then
+        with self.assertRaises(OkonomiyakiError):
+            EPDPlatform.from_string("win_x86-64")
+
     def test_epd_platform_from_string_new_names_underscore(self):
         # Given
         archs = ("i386", "x86", "i686")


### PR DESCRIPTION
BUG: fix error handling for platform strings with 'remains'.
(cherry picked from commit ecf8da9a267d7d86e03372dd21322b51fb866e92)