### PR TITLE
Merge pull request #258 from enthought/maint/fix-trove-classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ def main():
         license="BSD",
         version=__version__,
         classifiers=[
-            "Programming Language :: Python :: 2.7"
+            "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
         ],
     )


### PR DESCRIPTION
MAINT: fix invalid trove classifier in setup.py.
(cherry picked from commit 4346a8199fa704b57b452c2977e80ce22c0ec26c)