### PR TITLE
MAINT: mark classes we need hashable as immutable.

### DIFF
--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -202,7 +202,7 @@ def text_or_none_attr(**kw):
 
 
 @six.python_2_unicode_compatible
-@attributes
+@attributes(frozen=True)
 class Requirement(object):
     """
     Model for entries in the package metadata inside EGG-INFO/spec/depend

--- a/okonomiyaki/platforms/_arch.py
+++ b/okonomiyaki/platforms/_arch.py
@@ -35,7 +35,7 @@ _NORMALIZED_NAMES = {
 }
 
 
-@attributes
+@attributes(frozen=True)
 class Arch(object):
     """ A normalized architecture representation.
     """

--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -81,7 +81,7 @@ def platform_validator():
 
 
 @six.python_2_unicode_compatible
-@attributes
+@attributes(frozen=True)
 class EPDPlatform(object):
     """
     An sane Canopy/EPD platform representation.

--- a/okonomiyaki/platforms/platform.py
+++ b/okonomiyaki/platforms/platform.py
@@ -53,7 +53,7 @@ NAME_KIND_TO_PRETTY_NAMES = {
 
 
 @six.python_2_unicode_compatible
-@attributes(repr=False)
+@attributes(repr=False, frozen=True)
 class Platform(object):
     """
     An generic platform representation.


### PR DESCRIPTION
This is required by the new attrs 17.1.0 (see https://github.com/python-attrs/attrs/issues/191).