### PR TITLE
Fix/support using  run pep425 in frozen apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 dist/*
 okonomiyaki/_version.py
 *.egg-info
+*.pyc

--- a/okonomiyaki/platforms/_pep425_impl.py
+++ b/okonomiyaki/platforms/_pep425_impl.py
@@ -1,4 +1,4 @@
-_PEP425_IMPL='''\
+_PEP425_IMPL = '''\
 from __future__ import absolute_import, print_function
 
 import sys

--- a/okonomiyaki/platforms/_pep425_impl.py
+++ b/okonomiyaki/platforms/_pep425_impl.py
@@ -1,3 +1,4 @@
+_PEP425_IMPL='''\
 from __future__ import absolute_import, print_function
 
 import sys
@@ -140,3 +141,4 @@ if __name__ == "__main__":
         print(get_impl_tag())
     elif ns.platform_tag:
         print(get_platform())
+'''

--- a/okonomiyaki/platforms/_pep425_impl.py
+++ b/okonomiyaki/platforms/_pep425_impl.py
@@ -98,7 +98,7 @@ def _is_running_32bit():
 
 
 def get_platform():
-    import distutils
+    import distutils.util
     import platform
     """Return our platform name 'win32', 'linux_x86_64'"""
     if sys.platform == 'darwin':

--- a/okonomiyaki/platforms/pep425.py
+++ b/okonomiyaki/platforms/pep425.py
@@ -1,46 +1,48 @@
+import os
 import subprocess
+import sys
+import tempfile
 
 
 from okonomiyaki.utils import decode_if_needed
-from . import _pep425_impl
-
-
-_PEP425_IMPL = _pep425_impl.__file__
+from ._pep425_impl import _PEP425_IMPL
 
 
 def _run_pep425(executable, flag):
-    out = subprocess.check_output([executable, _PEP425_IMPL, flag]).strip()
+    with tempfile.NamedTemporaryFile(suffix='.py', delete=False) as handle:
+        handle.write(_PEP425_IMPL)
+    try:
+        out = subprocess.check_output([executable, handle.name, flag]).strip()
+    finally:
+        os.remove(handle.name)
     return decode_if_needed(out)
 
 
 def compute_abi_tag(python_executable=None):
     """ Compute the PEP425 abi tag for the given python executable.
 
-    This may launch a subprocess if python_executable is not the running python
+    This will launch a subprocess.
     """
     if python_executable is None:
-        return _pep425_impl.get_abi_tag()
-    else:
-        return _run_pep425(python_executable, "--abi-tag")
+        python_executable = sys.executable
+    return _run_pep425(python_executable, "--abi-tag")
 
 
 def compute_python_tag(python_executable=None):
     """ Compute the PEP425 python tag for the given python executable.
 
-    This may launch a subprocess if python_executable is not the running python
+    This will launch a subprocess.
     """
     if python_executable is None:
-        return _pep425_impl.get_impl_tag()
-    else:
-        return _run_pep425(python_executable, "--python-tag")
+        python_executable = sys.executable
+    return _run_pep425(python_executable, "--python-tag")
 
 
 def compute_platform_tag(python_executable=None):
     """ Compute the PEP425 platform tag for the given python executable.
 
-    This may launch a subprocess if python_executable is not the running python
+    This will launch a subprocess.
     """
     if python_executable is None:
-        return _pep425_impl.get_platform()
-    else:
-        return _run_pep425(python_executable, "--platform-tag")
+        python_executable = sys.executable
+    return _run_pep425(python_executable, "--platform-tag")

--- a/okonomiyaki/platforms/pep425.py
+++ b/okonomiyaki/platforms/pep425.py
@@ -9,7 +9,7 @@ from ._pep425_impl import _PEP425_IMPL
 
 
 def _run_pep425(executable, flag):
-    with tempfile.NamedTemporaryFile(suffix='.py', delete=False) as handle:
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as handle:
         handle.write(_PEP425_IMPL)
     try:
         out = subprocess.check_output([executable, handle.name, flag]).strip()


### PR DESCRIPTION
This PR update the way we call the run_pep415 script so that it can be used in frozen apps. Note that now a subprocess call will always take place.

fixes #283 

