### PR TITLE
Remove restriction on jsonschema 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ branches:
 
 install:
   - pip list
-  - pip install -q -U pip wheel coveralls;
+  - pip install -q -U pip attrs wheel coveralls;
   - pip install -q .
   - pip install -q -rdev_requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ branches:
     - maint/*
 
 install:
+  - pip list
   - pip install -q -U pip wheel coveralls;
   - pip install -q .
   - pip install -q -rdev_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 os: linux
-sudo: false
 
 env:
   global:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 INSTALL_REQUIRES = [
     "attrs >= 16.1.0",
-    "jsonschema >= 2.5.1, < 3.0.0",
+    "jsonschema >= 2.5.1",
     "six >= 1.9.0",
     "zipfile2 >= 0.0.12",
 ]


### PR DESCRIPTION
Fixes https://github.com/enthought/okonomiyaki/issues/317

The key to this fix ended up being to add in a `pip install -U` for `attrs` into the .travis.yml. `attrs` was pre-existing in the Travis CI and the version was not recent enough.