### PR TITLE
Fix build badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/enthought/okonomiyaki.png?branch=master
-    :target: https://travis-ci.org/enthought/okonomiyaki
+.. image:: https://travis-ci.com/enthought/okonomiyaki.svg?branch=master
+    :target: https://travis-ci.com/enthought/okonomiyaki
 
 Okonomiyaki is an experimental library aimed at consolidating a lot of our
 low-level code used for Enthought's eggs.


### PR DESCRIPTION
fixes #378 
Update the build badge and trigger the first build on travic-ci.com (migration from travis-ci.org)