### PR TITLE
Update script that verifies okonomiyaki can read eds eggs

### DIFF
--- a/scripts/check_parse_existing_eggs.py
+++ b/scripts/check_parse_existing_eggs.py
@@ -93,7 +93,8 @@ def make_test(organization, repository, platform, python_tag, path, strict):
         name, version, build, strictness).replace('-', '_').replace('.', '_')
 
     def test(self):
-        EggMetadata.from_egg(path, strict=strict)
+        metadata = EggMetadata.from_egg(path, strict=strict)
+        metadata.pkg_info.to_string()
 
     return test_name, test
 


### PR DESCRIPTION
Fix and update the failing script that checks the EDS eggs 

- Update code to support more recent versions of hatcher
- Add option to select the python version to check
- Always use sha256 to verify the eggs
- Make sure that we also check PKG_INFO generation 