### PR TITLE
Fix compute abi tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,9 @@ jobs:
     - name: Install test dependencies
       run: python -m pip install -r "dev_requirements.txt"
     - name: Test with haas
-      run: python -m haas okonomiyaki
+      run: |
+        cd jenkins
+        python -m haas okonomiyaki
   code-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [2.7, 3.6, 3.8]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ environment:
 
   global:
     PYTHONUNBUFFERED: "1"
-    runner: "haas"
     LANG: "ENG"
 
   matrix:
@@ -17,9 +16,7 @@ environment:
     - python: "C:/Python36-x64"
     - python: "C:/Python36"
     - python: "C:/Python38-x64"
-      runner: "unittest discover"
     - python: "C:/Python38"
-      runner: "unittest discover"
 
 branches:
   only:
@@ -42,4 +39,4 @@ install:
   - cmd: pip install -r dev_requirements.txt
 test_script:
   - cmd: cd jenkins
-  - cmd: coverage run -m %RUNNER% okonomiyaki
+  - cmd: coverage run -m haas okonomiyaki

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
 
   global:
     PYTHONUNBUFFERED: "1"
+    runner: "haas"
 
   matrix:
     - python: "C:/Python27-x64"
@@ -15,7 +16,9 @@ environment:
     - python: "C:/Python36-x64"
     - python: "C:/Python36"
     - python: "C:/Python38-x64"
+      runner: "unittest discover"
     - python: "C:/Python38"
+      runner: "unittest discover"
 
 branches:
   only:
@@ -37,4 +40,4 @@ install:
   - cmd: pip install .
   - cmd: pip install -r dev_requirements.txt
 test_script:
-  - cmd: coverage run -m haas okonomiyaki
+  - cmd: coverage run -m %RUNNER% okonomiyaki

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ environment:
     - python: "C:/Python35"
     - python: "C:/Python36-x64"
     - python: "C:/Python36"
+    - python: "C:/Python38-x64"
+    - python: "C:/Python38"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
   global:
     PYTHONUNBUFFERED: "1"
     runner: "haas"
+    LANG: "ENG"
 
   matrix:
     - python: "C:/Python27-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,4 +40,5 @@ install:
   - cmd: pip install .
   - cmd: pip install -r dev_requirements.txt
 test_script:
+  - cmd: cd jenkins
   - cmd: coverage run -m %RUNNER% okonomiyaki

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,3 +4,4 @@ flake8
 mock
 testfixtures
 hypothesis
+packaging >= 20.0

--- a/jenkins/test
+++ b/jenkins/test
@@ -46,7 +46,7 @@ pipeline {
         stage('setup') {
             steps {
                 execute "edm envs create okonomiyaki-dev --force"
-                execute "edm install -e okonomiyaki-dev -y haas mock testfixtures hypothesis packaging"
+                execute "edm install -e okonomiyaki-dev -y haas mock testfixtures hypothesis packaging>=20.0"
                 execute "edm run -e okonomiyaki-dev -- pip install -e ."
             }
         }

--- a/jenkins/test
+++ b/jenkins/test
@@ -46,7 +46,7 @@ pipeline {
         stage('setup') {
             steps {
                 execute "edm envs create okonomiyaki-dev --force"
-                execute "edm install -e okonomiyaki-dev -y haas mock testfixtures hypothesis"
+                execute "edm install -e okonomiyaki-dev -y haas mock testfixtures hypothesis packaging"
                 execute "edm run -e okonomiyaki-dev -- pip install -e ."
             }
         }

--- a/jenkins/test
+++ b/jenkins/test
@@ -46,8 +46,9 @@ pipeline {
         stage('setup') {
             steps {
                 execute "edm envs create okonomiyaki-dev --force"
-                execute "edm install -e okonomiyaki-dev -y haas mock testfixtures hypothesis 'packaging >= 20.0'"
+                execute "edm install -e okonomiyaki-dev -y haas mock testfixtures hypothesis"
                 execute "edm run -e okonomiyaki-dev -- pip install -e ."
+		execute "edm run -e okonomiyaki-dev -- pip install 'packaging >= 20.0'"
             }
         }
 

--- a/jenkins/test
+++ b/jenkins/test
@@ -46,7 +46,7 @@ pipeline {
         stage('setup') {
             steps {
                 execute "edm envs create okonomiyaki-dev --force"
-                execute "edm install -e okonomiyaki-dev -y haas mock testfixtures hypothesis packaging>=20.0"
+                execute "edm install -e okonomiyaki-dev -y haas mock testfixtures hypothesis 'packaging >= 20.0'"
                 execute "edm run -e okonomiyaki-dev -- pip install -e ."
             }
         }

--- a/okonomiyaki/file_formats/setuptools_egg.py
+++ b/okonomiyaki/file_formats/setuptools_egg.py
@@ -100,7 +100,7 @@ def _guess_abi_from_running_python():
             soabi = None
 
     if soabi and soabi.startswith('cpython-'):
-        return 'cp' + soabi.split('-', 1)[-1]
+        return 'cp' + soabi.split('-', 2)[1]
     else:
         return None
 

--- a/okonomiyaki/platforms/_pep425_impl.py
+++ b/okonomiyaki/platforms/_pep425_impl.py
@@ -76,7 +76,8 @@ def get_abi_tag():
         if get_flag('WITH_PYMALLOC',
                     lambda: impl == 'cp',
                     warn=(impl == 'cp')):
-            m = 'm'
+            if sys.version_info < (3, 8):
+                m = 'm'
         if get_flag('Py_UNICODE_SIZE',
                     lambda: sys.maxunicode == 0x10ffff,
                     expected=4,

--- a/okonomiyaki/platforms/_platform.py
+++ b/okonomiyaki/platforms/_platform.py
@@ -153,9 +153,7 @@ def _guess_platform_details(os_kind):
     elif os_kind == OSKind.darwin:
         return FamilyKind.mac_os_x, NameKind.mac_os_x, platform.mac_ver()[0]
     elif os_kind == OSKind.linux:
-        name = platform.linux_distribution()[0].lower()
-        name = name.split()[0]
-        _, release, _ = platform.dist()
+        name, release = _linux_distribution()
         try:
             name_kind = NameKind[name]
         except KeyError:
@@ -183,3 +181,18 @@ def _guess_platform(arch_string=None):
     family_kind, name_kind, release = _guess_platform_details(os_kind)
 
     return Platform(os_kind, name_kind, family_kind, release, arch, machine)
+
+
+def _linux_distribution():
+    """ Get the linux distribution of the running system.
+
+    """
+    try:
+        name, release, _ = platform.linux_distribution()
+    except AttributeError:
+        # We are probably running on Python > 3.8
+        # see https://docs.python.org/3.6/library/platform.html?highlight=linux_distribution#unix-platforms
+        import distro
+        name, release, _ = distro.linux_distribution()
+    name = name.lower().split()[0]
+    return name, release

--- a/okonomiyaki/platforms/_platform.py
+++ b/okonomiyaki/platforms/_platform.py
@@ -194,5 +194,5 @@ def _linux_distribution():
         # see https://docs.python.org/3.6/library/platform.html?highlight=linux_distribution#unix-platforms
         import distro
         name, release, _ = distro.linux_distribution()
-    name = name.lower().split()[0]
-    return name, release
+    name = name.split()[0]
+    return name.lower(), release

--- a/okonomiyaki/platforms/tests/common.py
+++ b/okonomiyaki/platforms/tests/common.py
@@ -51,49 +51,41 @@ mock_windows = MultiPatcher([
 ])
 
 
-# OS Version mocking
-def _mock_platform_dist(info):
-    return Patcher(mock.patch("platform.dist", lambda: info))
-
-
-def _mock_platform_linux_distribution(info):
-    return Patcher(mock.patch("platform.linux_distribution", lambda: info))
-
+if sys.version_info < (3, 8):
+    def _mock_linux_distribution(info):
+        return Patcher(mock.patch("platform.linux_distribution", lambda: info))
+else:
+    def _mock_linux_distribution(info):
+        return Patcher(mock.patch("distro.linux_distribution", lambda: info))
 
 mock_centos_3_5 = MultiPatcher([
     mock_linux,
-    _mock_platform_dist(("redhat", "3.5", "Final")),
-    _mock_platform_linux_distribution(("CentOS", "3.5", "Final"))
+    _mock_linux_distribution(("CentOS", "3.5", "Final"))
 ])
 
 mock_centos_5_8 = MultiPatcher([
     mock_linux,
-    _mock_platform_dist(("redhat", "5.8", "Final")),
-    _mock_platform_linux_distribution(("CentOS", "5.8", "Final"))
+    _mock_linux_distribution(("CentOS", "5.8", "Final"))
 ])
 
 mock_centos_6_3 = MultiPatcher([
     mock_linux,
-    _mock_platform_dist(("redhat", "6.3", "Final")),
-    _mock_platform_linux_distribution(("CentOS", "6.3", "Final"))
+   _mock_linux_distribution(("CentOS", "6.3", "Final"))
 ])
 
 mock_centos_7_0 = MultiPatcher([
     mock_linux,
-    _mock_platform_dist(("redhat", "7.0", "Final")),
-    _mock_platform_linux_distribution(("CentOS", "7.0", "Final"))
+    _mock_linux_distribution(("CentOS", "7.0", "Final"))
 ])
 
 mock_centos_7_6 = MultiPatcher([
     mock_linux,
-    _mock_platform_dist(("centos", "7.6.1810", "Core")),
-    _mock_platform_linux_distribution(("CentOS Linux", "7.6.1810", "Core"))
+    _mock_linux_distribution(("CentOS Linux", "7.6.1810", "Core"))
 ])
 
 mock_ubuntu_raring = MultiPatcher([
-    _mock_platform_dist(("Ubuntu", "13.04", "raring")),
-    _mock_platform_linux_distribution(("Ubuntu", "13.04", "raring")),
     mock_linux,
+    _mock_linux_distribution(("Ubuntu", "13.04", "raring")),
 ])
 
 mock_windows_7 = MultiPatcher([

--- a/okonomiyaki/platforms/tests/common.py
+++ b/okonomiyaki/platforms/tests/common.py
@@ -70,7 +70,7 @@ mock_centos_5_8 = MultiPatcher([
 
 mock_centos_6_3 = MultiPatcher([
     mock_linux,
-   _mock_linux_distribution(("CentOS", "6.3", "Final"))
+    _mock_linux_distribution(("CentOS", "6.3", "Final"))
 ])
 
 mock_centos_7_0 = MultiPatcher([

--- a/okonomiyaki/platforms/tests/test_pep425.py
+++ b/okonomiyaki/platforms/tests/test_pep425.py
@@ -17,65 +17,61 @@ def _system_tags():
 
 
 class TestPEP425(unittest.TestCase):
+
+    def setUp(self):
+        self.tag = next(
+            tag for tag in
+            _system_tags()
+            # We do not support the manylinux tag
+            if 'manylinux' not in tag.platform)
+
     def test_abi_tag(self):
         # Given
         executable = sys.executable
-        tag = next(_system_tags())
 
         # When
         abi_tag = compute_abi_tag(executable)
 
         # Then
-        self.assertEqual(abi_tag, tag.abi)
+        self.assertEqual(abi_tag, self.tag.abi)
 
     def test_abi_tag_default(self):
-        # Given
-        tag = next(_system_tags())
-
         # When
         abi_tag = compute_abi_tag()
 
         # Then
-        self.assertEqual(abi_tag, tag.abi)
+        self.assertEqual(abi_tag, self.tag.abi)
 
     def test_python_tag(self):
         # Given
         executable = sys.executable
-        tag = next(_system_tags())
 
         # When
         python_tag = compute_python_tag(executable)
 
         # Then
-        self.assertEqual(python_tag, tag.interpreter)
+        self.assertEqual(python_tag, self.tag.interpreter)
 
     def test_python_tag_default(self):
-        # Given
-        tag = next(_system_tags())
-
         # When
         python_tag = compute_python_tag()
 
         # Then
-        self.assertEqual(python_tag, tag.interpreter)
+        self.assertEqual(python_tag, self.tag.interpreter)
 
     def test_platform_tag(self):
         # Given
         executable = sys.executable
-        tag = next(_system_tags())
 
         # When
         platform_tag = compute_platform_tag(executable)
 
         # Then
-        self.assertEqual(platform_tag, tag.platform)
+        self.assertEqual(platform_tag, self.tag.platform)
 
     def test_platform_tag_default(self):
-        # Given
-        tag = next(_system_tags())
-
         # When
         platform_tag = compute_platform_tag()
 
         # Then
-        self.assertEqual(platform_tag, tag.platform)
+        self.assertEqual(platform_tag, self.tag.platform)

--- a/okonomiyaki/platforms/tests/test_pep425.py
+++ b/okonomiyaki/platforms/tests/test_pep425.py
@@ -5,12 +5,16 @@ from packaging import tags
 
 from ..pep425 import compute_abi_tag, compute_python_tag, compute_platform_tag
 
+
 def _system_tags():
     interp_name = tags.interpreter_name()
     if interp_name == "cp":
-        yield from tags.cpython_tags()
+        for tag in tags.cpython_tags():
+            yield tag
     else:
-        yield from tags.generic_tags()
+        for tag in tags.generic_tags():
+            yield tag
+
 
 class TestPEP425(unittest.TestCase):
     def test_abi_tag(self):

--- a/okonomiyaki/platforms/tests/test_pep425.py
+++ b/okonomiyaki/platforms/tests/test_pep425.py
@@ -1,79 +1,77 @@
 import sys
 import unittest
 
-try:
-    from pip import pep425tags as pip_pep425
-    HAS_PIP_PEP425 = True
-except ImportError as e:
-    print(e)
-    HAS_PIP_PEP425 = False
+from packaging import tags
 
 from ..pep425 import compute_abi_tag, compute_python_tag, compute_platform_tag
 
+def _system_tags():
+    interp_name = tags.interpreter_name()
+    if interp_name == "cp":
+        yield from tags.cpython_tags()
+    else:
+        yield from tags.generic_tags()
 
-@unittest.skipIf(
-    not HAS_PIP_PEP425, "Could not import pip.pep425 for comparison"
-)
 class TestPEP425(unittest.TestCase):
     def test_abi_tag(self):
         # Given
         executable = sys.executable
-        r_abi_tag = pip_pep425.get_abi_tag()
+        tag = next(_system_tags())
 
         # When
         abi_tag = compute_abi_tag(executable)
 
         # Then
-        self.assertEqual(abi_tag, r_abi_tag)
+        self.assertEqual(abi_tag, tag.abi)
 
     def test_abi_tag_default(self):
         # Given
-        r_abi_tag = pip_pep425.get_abi_tag()
+        tag = next(_system_tags())
 
         # When
         abi_tag = compute_abi_tag()
 
         # Then
-        self.assertEqual(abi_tag, r_abi_tag)
+        self.assertEqual(abi_tag, tag.abi)
 
     def test_python_tag(self):
         # Given
         executable = sys.executable
-        r_python_tag = pip_pep425.get_impl_tag()
+        tag = next(_system_tags())
 
         # When
         python_tag = compute_python_tag(executable)
 
         # Then
-        self.assertEqual(python_tag, r_python_tag)
+        self.assertEqual(python_tag, tag.interpreter)
 
     def test_python_tag_default(self):
         # Given
-        r_python_tag = pip_pep425.get_impl_tag()
+        tag = next(_system_tags())
 
         # When
         python_tag = compute_python_tag()
 
         # Then
-        self.assertEqual(python_tag, r_python_tag)
+        self.assertEqual(python_tag, tag.interpreter)
 
     def test_platform_tag(self):
         # Given
         executable = sys.executable
-        r_platform_tag = pip_pep425.get_platform()
+        tag = next(_system_tags())
 
         # When
         platform_tag = compute_platform_tag(executable)
 
         # Then
-        self.assertEqual(platform_tag, r_platform_tag)
+        self.assertEqual(platform_tag, tag.platform)
 
     def test_platform_tag_default(self):
         # Given
-        r_platform_tag = pip_pep425.get_platform()
+        tag = next(_system_tags())
 
         # When
         platform_tag = compute_platform_tag()
 
         # Then
-        self.assertEqual(platform_tag, r_platform_tag)
+        self.assertEqual(platform_tag, tag.platform)

--- a/okonomiyaki/runtimes/tests/test_runtime_info.py
+++ b/okonomiyaki/runtimes/tests/test_runtime_info.py
@@ -37,7 +37,9 @@ class TestPythonRuntimeInfoV1(unittest.TestCase):
         # Then
         self.assertEqual(runtime_info.prefix, prefix)
         self.assertEqual(runtime_info.name, name)
-        self.assertEqual(runtime_info.executable, r_executable)
+        self.assertEqual(
+            os.path.realpath(runtime_info.executable),
+            os.path.realpath(r_executable))
 
     def test_dollar_in_prefix(self):
         # Given
@@ -61,7 +63,9 @@ class TestPythonRuntimeInfoV1(unittest.TestCase):
         # Then
         self.assertEqual(runtime_info.prefix, prefix)
         self.assertEqual(runtime_info.name, name)
-        self.assertEqual(runtime_info.executable, r_executable)
+        self.assertEqual(
+            os.path.realpath(runtime_info.executable),
+            os.path.realpath(r_executable))
 
     def test_json_round_trip(self):
         # Given
@@ -106,7 +110,9 @@ class TestJuliaRuntimeInfoV1(unittest.TestCase):
         # Then
         self.assertEqual(runtime_info.prefix, prefix)
         self.assertEqual(runtime_info.name, name)
-        self.assertEqual(runtime_info.executable, r_executable)
+        self.assertEqual(
+            os.path.realpath(runtime_info.executable),
+            os.path.realpath(r_executable))
 
     def test_json_round_trip(self):
         # Given

--- a/okonomiyaki/utils/tests/test_eggs.py
+++ b/okonomiyaki/utils/tests/test_eggs.py
@@ -15,6 +15,7 @@ class TestDummyEggs(unittest.TestCase):
     def test_cp38_egg_metadata_valid(self, filepath):
         # when
         metadata = EggMetadata.from_egg(filepath)
+        filepath = filepath.lower()
 
         # then
         if 'mkl' in metadata.name:
@@ -37,6 +38,7 @@ class TestDummyEggs(unittest.TestCase):
     def test_cp27_egg_metadata_valid(self, filepath):
         # when
         metadata = EggMetadata.from_egg(filepath)
+        filepath = filepath.lower()
 
         # then
         if 'mkl' in metadata.name:

--- a/okonomiyaki/utils/tests/test_eggs.py
+++ b/okonomiyaki/utils/tests/test_eggs.py
@@ -24,10 +24,10 @@ class TestDummyEggs(unittest.TestCase):
         else:
             self.assertEqual(metadata.python_tag, 'cp38')
             self.assertEqual(metadata.abi_tag, 'cp38')
-        if 'osx' in filepath:
+        if 'osx_x86_64' in filepath:
             self.assertEqual(metadata.platform_tag, 'macosx_10_14_x86_64')
             self.assertEqual(metadata.platform_abi, PlatformABI(u'darwin'))
-        elif 'win' in filepath:
+        elif 'win_x86_64' in filepath:
             self.assertEqual(metadata.platform_tag, 'win_amd64')
             self.assertEqual(metadata.platform_abi, PlatformABI(u'msvc2019'))
         else:
@@ -47,10 +47,10 @@ class TestDummyEggs(unittest.TestCase):
         else:
             self.assertIn(metadata.python_tag, 'cp27')
             self.assertIn(metadata.abi_tag, 'cp27m')
-        if 'osx' in filepath:
+        if 'osx_x86_64' in filepath:
             self.assertEqual(metadata.platform_tag, 'macosx_10_6_x86_64')
             self.assertEqual(metadata.platform_abi, PlatformABI(u'darwin'))
-        elif 'win' in filepath:
+        elif 'win_x86_64' in filepath:
             self.assertEqual(metadata.platform_tag, 'win_amd64')
             self.assertEqual(metadata.platform_abi, PlatformABI(u'msvc2008'))
         else:

--- a/okonomiyaki/utils/tests/test_eggs.py
+++ b/okonomiyaki/utils/tests/test_eggs.py
@@ -26,12 +26,12 @@ class TestDummyEggs(unittest.TestCase):
         if 'osx' in filepath:
             self.assertEqual(metadata.platform_tag, 'macosx_10_14_x86_64')
             self.assertEqual(metadata.platform_abi, PlatformABI(u'darwin'))
-        elif 'rh7' in filepath:
-            self.assertEqual(metadata.platform_tag, 'linux_x86_64')
-            self.assertEqual(metadata.platform_abi, PlatformABI(u'gnu'))
         elif 'win' in filepath:
             self.assertEqual(metadata.platform_tag, 'win_amd64')
             self.assertEqual(metadata.platform_abi, PlatformABI(u'msvc2019'))
+        else:
+            self.assertEqual(metadata.platform_tag, 'linux_x86_64')
+            self.assertEqual(metadata.platform_abi, PlatformABI(u'gnu'))
 
     @given(sampled_from(CP27_EGGS))
     def test_cp27_egg_metadata_valid(self, filepath):
@@ -48,9 +48,9 @@ class TestDummyEggs(unittest.TestCase):
         if 'osx' in filepath:
             self.assertEqual(metadata.platform_tag, 'macosx_10_6_x86_64')
             self.assertEqual(metadata.platform_abi, PlatformABI(u'darwin'))
-        elif 'rh7' in filepath:
-            self.assertEqual(metadata.platform_tag, 'linux_x86_64')
-            self.assertEqual(metadata.platform_abi, PlatformABI(u'gnu'))
         elif 'win' in filepath:
             self.assertEqual(metadata.platform_tag, 'win_amd64')
             self.assertEqual(metadata.platform_abi, PlatformABI(u'msvc2008'))
+        else:
+            self.assertEqual(metadata.platform_tag, 'linux_x86_64')
+            self.assertEqual(metadata.platform_abi, PlatformABI(u'gnu'))

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ INSTALL_REQUIRES = [
 
 EXTRAS_REQUIRE = {
     ':python_version=="2.7"': ['enum34'],
+    ':python_version>="3.8"': ['distro'],
 }
 
 


### PR DESCRIPTION
fixes #421 
fixes #385 

In more details

- Update the vendorized pep425 module to better support python 3.8
- Update pep425 tests to use packaging.tag to verify results
- Add testing on Python 3.8 (to verify that the pep425 changes are correct)
~- Fix relative imports. The rule of thumb is that we should not use `..` for library code and `...` for test code (it was causing issue running the tests locally from the root folder)~
- Fix _guess_platform_details function to support python 3.8 
- Update ci builds