### PR TITLE
Fix relative imports

### DIFF
--- a/okonomiyaki/_cli/__init__.py
+++ b/okonomiyaki/_cli/__init__.py
@@ -3,8 +3,8 @@ import sys
 
 import zipfile2
 
-from ..file_formats import EggMetadata
-from ..versions import MetadataVersion
+from okonomiyaki.file_formats import EggMetadata
+from okonomiyaki.versions import MetadataVersion
 
 
 def _metadata_from_path(path, sha256):

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -7,31 +7,25 @@ import zipfile2
 from attr import attr, attributes
 from attr.validators import instance_of, optional
 
-from ..errors import (
+from okonomiyaki.errors import (
     InvalidRequirementString, InvalidRequirementStringHyphen,
     InvalidEggName, InvalidMetadataField,
-    MissingMetadata, UnsupportedMetadata
-)
-from ..platforms import (
-    EPDPlatform, PlatformABI, PythonABI, PythonImplementation
-)
-from ..platforms.legacy import LegacyEPDPlatform
-from ..utils import (
-    compute_sha256, decode_if_needed, encode_if_needed, parse_assignments
-)
-from ..utils.py3compat import StringIO, string_types
-from ..versions import EnpkgVersion, MetadataVersion
+    MissingMetadata, UnsupportedMetadata)
+from okonomiyaki.platforms.legacy import LegacyEPDPlatform
+from okonomiyaki.platforms import (
+    EPDPlatform, PlatformABI, PythonABI, PythonImplementation)
+from okonomiyaki.utils import (
+    compute_sha256, decode_if_needed, encode_if_needed, parse_assignments)
+from okonomiyaki.utils.py3compat import StringIO, string_types
+from okonomiyaki.versions import EnpkgVersion, MetadataVersion
 from .legacy import (
-    _guess_abi_tag, _guess_platform_abi, _guess_platform_tag, _guess_python_tag
-)
+    _guess_abi_tag, _guess_platform_abi, _guess_platform_tag, _guess_python_tag)
 from ._blacklist import (
     EGG_PLATFORM_BLACK_LIST, EGG_PYTHON_TAG_BLACK_LIST,
     may_be_in_platform_blacklist, may_be_in_python_tag_blacklist,
-    may_be_in_pkg_info_blacklist
-)
+    may_be_in_pkg_info_blacklist)
 from ._package_info import (
-    PackageInfo, _convert_if_needed, _keep_position, _read_pkg_info
-)
+    PackageInfo, _convert_if_needed, _keep_position, _read_pkg_info)
 
 
 _EGG_NAME_RE = re.compile(r"""

--- a/okonomiyaki/file_formats/_package_info.py
+++ b/okonomiyaki/file_formats/_package_info.py
@@ -9,8 +9,8 @@ import warnings
 
 import zipfile2
 
-from ..utils import py3compat, compute_sha256
-from ..errors import OkonomiyakiError
+from okonomiyaki.utils import py3compat, compute_sha256
+from okonomiyaki.errors import OkonomiyakiError
 
 from ._blacklist import EGG_PKG_INFO_BLACK_LIST, may_be_in_pkg_info_blacklist
 from ._wheel_info import WheelInfo

--- a/okonomiyaki/file_formats/legacy.py
+++ b/okonomiyaki/file_formats/legacy.py
@@ -3,9 +3,9 @@ metadata.
 """
 import re
 
-from ..errors import InvalidMetadataField
-from ..platforms import PythonImplementation, default_abi
-from ..versions import RuntimeVersion
+from okonomiyaki.errors import InvalidMetadataField
+from okonomiyaki.platforms import PythonImplementation, default_abi
+from okonomiyaki.versions import RuntimeVersion
 
 # To parse the python field in our index and spec/depend
 _PYVER_RE = re.compile(r"(?P<major>\d+)\.(?P<minor>\d+)")

--- a/okonomiyaki/file_formats/setuptools_egg.py
+++ b/okonomiyaki/file_formats/setuptools_egg.py
@@ -7,9 +7,9 @@ except ImportError:  # Python 2.6 support
     sysconfig = None
 import warnings
 
-from ..errors import OkonomiyakiError
-from ..platforms import PythonImplementation
-from ..utils import py3compat
+from okonomiyaki.errors import OkonomiyakiError
+from okonomiyaki.platforms import PythonImplementation
+from okonomiyaki.utils import py3compat
 from ._egg_info import _guess_python_tag
 from ._package_info import PackageInfo
 

--- a/okonomiyaki/file_formats/tests/common.py
+++ b/okonomiyaki/file_formats/tests/common.py
@@ -2,7 +2,7 @@
 import io
 import os.path
 
-from ... import repositories
+from okonomiyaki import repositories
 
 DATA_DIR = os.path.join(
     os.path.dirname(repositories.__file__), "tests", "data")

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -13,29 +13,25 @@ if sys.version_info < (2, 7):  # noqa
 else:
     import unittest
 
-from ...errors import (
+from okonomiyaki.errors import (
     InvalidEggName, InvalidMetadataField, MissingMetadata, UnsupportedMetadata,
-    InvalidRequirementStringHyphen
-)
-from ...utils import tempdir
-from ...utils.test_data import (
-    MKL_10_3_RH5_X86_64, NOSE_1_3_4_RH6_X86_64, NOSE_1_3_4_RH5_X86_64
-)
-from ...platforms import EPDPlatform, PlatformABI
-from ...platforms.legacy import LegacyEPDPlatform
-from ...versions import EnpkgVersion, MetadataVersion
+    InvalidRequirementStringHyphen)
+from okonomiyaki.utils import tempdir
+from okonomiyaki.utils.test_data import (
+    MKL_10_3_RH5_X86_64, NOSE_1_3_4_RH6_X86_64, NOSE_1_3_4_RH5_X86_64)
+from okonomiyaki.platforms import EPDPlatform, PlatformABI
+from okonomiyaki.platforms.legacy import LegacyEPDPlatform
+from okonomiyaki.versions import EnpkgVersion, MetadataVersion
 
 from .._egg_info import (
     Requirement, EggMetadata, LegacySpecDepend, parse_rawspec,
-    split_egg_name
-)
+    split_egg_name)
 
 from .common import (
     BROKEN_MCCABE_EGG, DATA_DIR, ENSTALLER_EGG, ETS_EGG,
     FAKE_MEDIALOG_BOARDFILE_1_6_1_EGG, FAKE_MEDIALOG_BOARDFILE_1_6_1_PKG_INFO,
     MKL_EGG, NUMEXPR_2_2_2_EGG, PYMULTINEST_EGG, _OSX64APP_EGG,
-    PYSIDE_1_0_3_EGG, XZ_5_2_0_EGG
-)
+    PYSIDE_1_0_3_EGG, XZ_5_2_0_EGG)
 
 
 M = MetadataVersion.from_string

--- a/okonomiyaki/file_formats/tests/test__package_info.py
+++ b/okonomiyaki/file_formats/tests/test__package_info.py
@@ -15,7 +15,7 @@ else:
     import unittest
 
 from okonomiyaki.utils.test_data import OKONOMIYAKI_0_17_0_PY2
-from ...errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 from .common import (
     BROKEN_MCCABE_EGG, PIP_EGG, PKG_INFO_ENSTALLER_1_0_DESCRIPTION,
     PIP_PKG_INFO, PKG_INFO_ENSTALLER_1_0, PYMULTINEST_EGG, SUPERVISOR_EGG,

--- a/okonomiyaki/file_formats/tests/test_egg_file_format.py
+++ b/okonomiyaki/file_formats/tests/test_egg_file_format.py
@@ -15,10 +15,10 @@ else:
 
 import os.path as op
 
-from ...platforms import EPDPlatform
-from ...utils import compute_md5
-from ...utils import py3compat
-from ...versions import EnpkgVersion
+from okonomiyaki.platforms import EPDPlatform
+from okonomiyaki.utils import compute_md5
+from okonomiyaki.utils import py3compat
+from okonomiyaki.versions import EnpkgVersion
 
 from ..egg import EggBuilder, EggRewriter
 from .._egg_info import Dependencies, EggMetadata, LegacySpecDepend

--- a/okonomiyaki/platforms/_arch.py
+++ b/okonomiyaki/platforms/_arch.py
@@ -8,7 +8,7 @@ import enum
 from attr import attr, attributes
 from attr.validators import instance_of
 
-from ..errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 
 
 @enum.unique

--- a/okonomiyaki/platforms/_platform.py
+++ b/okonomiyaki/platforms/_platform.py
@@ -9,7 +9,7 @@ import six
 from attr import attr, attributes
 from attr.validators import instance_of
 
-from ..errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 
 from ._arch import Arch
 

--- a/okonomiyaki/platforms/abi.py
+++ b/okonomiyaki/platforms/abi.py
@@ -3,8 +3,8 @@ import six
 from attr import attributes, attr
 from attr.validators import instance_of
 
-from ..errors import OkonomiyakiError
-from ..versions import RuntimeVersion
+from okonomiyaki.errors import OkonomiyakiError
+from okonomiyaki.versions import RuntimeVersion
 
 from .epd_platform import EPDPlatform
 from ._platform import OSKind

--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -8,8 +8,8 @@ import six
 from attr import attributes, attr
 from attr.validators import instance_of
 
-from ..versions import RuntimeVersion
-from ..errors import OkonomiyakiError, InvalidPEP440Version
+from okonomiyaki.versions import RuntimeVersion
+from okonomiyaki.errors import OkonomiyakiError, InvalidPEP440Version
 from ._arch import Arch, ArchitectureKind
 from ._platform import OSKind, FamilyKind, NameKind, Platform
 

--- a/okonomiyaki/platforms/legacy.py
+++ b/okonomiyaki/platforms/legacy.py
@@ -1,7 +1,7 @@
 from attr import attributes, attr
 from attr.validators import instance_of
 
-from ..errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 
 from .epd_platform import EPDPlatform
 

--- a/okonomiyaki/platforms/platform_filters.py
+++ b/okonomiyaki/platforms/platform_filters.py
@@ -5,7 +5,7 @@ import six
 from attr import attr, attributes
 from attr.validators import instance_of, optional
 
-from ..errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 
 from ._arch import Arch
 from .epd_platform import EPDPlatform

--- a/okonomiyaki/platforms/python_implementation.py
+++ b/okonomiyaki/platforms/python_implementation.py
@@ -6,7 +6,7 @@ import six
 from attr import attributes, attr
 from attr.validators import instance_of
 
-from ..errors import InvalidMetadataField
+from okonomiyaki.errors import InvalidMetadataField
 
 
 _KIND_TO_ABBREVIATED = {

--- a/okonomiyaki/platforms/tests/common.py
+++ b/okonomiyaki/platforms/tests/common.py
@@ -2,7 +2,7 @@ import collections
 import mock
 import sys
 
-from ...utils.testing import MultiPatcher, Patcher
+from okonomiyaki.utils.testing import MultiPatcher, Patcher
 
 
 # OS mocking

--- a/okonomiyaki/platforms/tests/test__arch.py
+++ b/okonomiyaki/platforms/tests/test__arch.py
@@ -1,6 +1,6 @@
 import sys
 
-from ...errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 from .._arch import Arch
 
 from .common import (mock_machine_armv71, mock_x86, mock_x86_64,

--- a/okonomiyaki/platforms/tests/test_abi.py
+++ b/okonomiyaki/platforms/tests/test_abi.py
@@ -8,7 +8,7 @@ else:
 from hypothesis import given
 from hypothesis.strategies import sampled_from
 
-from ...errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 from ..abi import default_abi
 
 

--- a/okonomiyaki/platforms/tests/test_platform.py
+++ b/okonomiyaki/platforms/tests/test_platform.py
@@ -1,6 +1,6 @@
 import sys
 
-from ...errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 from ..epd_platform import EPDPlatform
 from .._platform import Platform
 

--- a/okonomiyaki/platforms/tests/test_python_implementation.py
+++ b/okonomiyaki/platforms/tests/test_python_implementation.py
@@ -3,8 +3,8 @@ import sys
 import mock
 import six
 
+from okonomiyaki.errors import InvalidMetadataField
 from ..python_implementation import PythonABI, PythonImplementation
-from ...errors import InvalidMetadataField
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest

--- a/okonomiyaki/runtimes/common.py
+++ b/okonomiyaki/runtimes/common.py
@@ -1,4 +1,4 @@
-from ..platforms import EPDPlatform
+from okonomiyaki.platforms import EPDPlatform
 
 
 def _platform_string(platform):

--- a/okonomiyaki/runtimes/runtime.py
+++ b/okonomiyaki/runtimes/runtime.py
@@ -7,8 +7,8 @@ import six
 from attr import attr, attributes
 from attr.validators import instance_of
 
-from ..platforms import OSKind, Platform, default_abi
-from ..versions import MetadataVersion, RuntimeVersion
+from okonomiyaki.platforms import OSKind, Platform, default_abi
+from okonomiyaki.versions import MetadataVersion, RuntimeVersion
 
 from .runtime_info import IRuntimeInfoV1, PythonRuntimeInfoV1
 

--- a/okonomiyaki/runtimes/runtime_info.py
+++ b/okonomiyaki/runtimes/runtime_info.py
@@ -7,10 +7,10 @@ import six
 from attr import asdict, attr, attributes
 from attr.validators import instance_of
 
-from ..errors import UnsupportedMetadata
-from ..platforms import Platform
-from ..utils import substitute_variable, substitute_variables
-from ..versions import MetadataVersion, RuntimeVersion
+from okonomiyaki.errors import UnsupportedMetadata
+from okonomiyaki.platforms import Platform
+from okonomiyaki.utils import substitute_variable, substitute_variables
+from okonomiyaki.versions import MetadataVersion, RuntimeVersion
 
 from .common import _platform_string
 from .runtime_metadata import JuliaRuntimeMetadataV1, PythonRuntimeMetadataV1

--- a/okonomiyaki/runtimes/runtime_metadata.py
+++ b/okonomiyaki/runtimes/runtime_metadata.py
@@ -11,10 +11,10 @@ import zipfile2
 from attr import attr, attributes
 from attr.validators import instance_of
 
-from ..errors import InvalidMetadata, MissingMetadata, UnsupportedMetadata
-from ..platforms import EPDPlatform, Platform
-from ..platforms.abi import _PLATFORM_ABI_NONE
-from ..versions import MetadataVersion, RuntimeVersion
+from okonomiyaki.errors import InvalidMetadata, MissingMetadata, UnsupportedMetadata
+from okonomiyaki.platforms import EPDPlatform, Platform
+from okonomiyaki.platforms.abi import _PLATFORM_ABI_NONE
+from okonomiyaki.versions import MetadataVersion, RuntimeVersion
 
 from .common import _platform_string
 from .runtime_schemas import _JULIA_V1, _PYTHON_V1

--- a/okonomiyaki/utils/misc.py
+++ b/okonomiyaki/utils/misc.py
@@ -7,7 +7,7 @@ import tempfile
 
 from .py3compat import string_types
 
-from ..errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 
 
 class _AssignmentParser(ast.NodeVisitor):

--- a/okonomiyaki/utils/tests/test_misc.py
+++ b/okonomiyaki/utils/tests/test_misc.py
@@ -1,7 +1,7 @@
 import sys
 import textwrap
 
-from ...errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 from ..misc import parse_assignments, substitute_variables, substitute_variable
 from ..py3compat import StringIO
 

--- a/okonomiyaki/versions/enpkg.py
+++ b/okonomiyaki/versions/enpkg.py
@@ -1,5 +1,4 @@
-from ..errors import InvalidEnpkgVersion
-
+from okonomiyaki.errors import InvalidEnpkgVersion
 from .pep386_workaround import IrrationalVersionError, PEP386WorkaroundVersion
 
 

--- a/okonomiyaki/versions/metadata_version.py
+++ b/okonomiyaki/versions/metadata_version.py
@@ -1,6 +1,6 @@
 import re
 
-from ..errors import InvalidMetadataVersion
+from okonomiyaki.errors import InvalidMetadataVersion
 
 
 _VERSION_R = re.compile(r"(?P<major>\d+)\.(?P<minor>\d+)$")

--- a/okonomiyaki/versions/pep440.py
+++ b/okonomiyaki/versions/pep440.py
@@ -4,7 +4,7 @@ Implementation adapted from the distlib.version package
 """
 import re
 
-from ..errors import InvalidPEP440Version
+from okonomiyaki.errors import InvalidPEP440Version
 
 
 PEP440_VERSION_RE = re.compile(r'^v?(\d+!)?(\d+(\.\d+)*)((a|b|rc)(\d+))?'

--- a/okonomiyaki/versions/semver.py
+++ b/okonomiyaki/versions/semver.py
@@ -1,7 +1,7 @@
 import re
 
-from ..errors import InvalidSemanticVersion
-from ..utils.py3compat import long
+from okonomiyaki.errors import InvalidSemanticVersion
+from okonomiyaki.utils.py3compat import long
 
 
 _SEMVER_R = re.compile(r"""


### PR DESCRIPTION
- Only `.` should be used for package modules
- Only `..` and `.` should be used for test code inside subpackages

Note that this rule makes the subpackages relocatable