### PR TITLE
Fix repr issues

### DIFF
--- a/okonomiyaki/versions/pep440.py
+++ b/okonomiyaki/versions/pep440.py
@@ -190,7 +190,7 @@ class PEP440Version(object):
         return self._parts > other._parts
 
     def __repr__(self):
-        return "{0}('{1}')".format(self.__class__.__name__, str(self))
+        return "{0}.from_string('{1!s}')".format(self.__class__.__name__, self)
 
     def __str__(self):
         if self._string is None:

--- a/okonomiyaki/versions/runtime_version.py
+++ b/okonomiyaki/versions/runtime_version.py
@@ -48,6 +48,9 @@ class RuntimeVersion(object):
     def __str__(self):
         return str(self._pep440_version)
 
+    def __repr__(self):
+        return "{0}.from_string('{1!s}')".format(self.__class__.__name__, self)
+
     def __hash__(self):
         return hash(self._pep440_version)
 

--- a/okonomiyaki/versions/tests/test_pep440.py
+++ b/okonomiyaki/versions/tests/test_pep440.py
@@ -185,6 +185,17 @@ class TestPEP440Version(unittest.TestCase):
         # When/Then
         self.assertEqual(hash(v1), hash(v2))
 
+    def test_repr(self):
+        # Given
+        v1 = V("1.2.0")
+
+        # When
+        result = repr(v1)
+
+        # Then
+        self.assertEqual(repr(v1), "PEP440Version.from_string('1.2.0')")
+        self.assertEqual(eval(result), v1)
+
     def test_invalid(self):
         # Given
         left = V("1.0")

--- a/okonomiyaki/versions/tests/test_pep440.py
+++ b/okonomiyaki/versions/tests/test_pep440.py
@@ -193,7 +193,7 @@ class TestPEP440Version(unittest.TestCase):
         result = repr(v1)
 
         # Then
-        self.assertEqual(repr(v1), "PEP440Version.from_string('1.2.0')")
+        self.assertEqual(result, "PEP440Version.from_string('1.2.0')")
         self.assertEqual(eval(result), v1)
 
     def test_invalid(self):

--- a/okonomiyaki/versions/tests/test_runtime_version.py
+++ b/okonomiyaki/versions/tests/test_runtime_version.py
@@ -63,7 +63,7 @@ class TestRuntimeVersion(unittest.TestCase):
         result = repr(v1)
 
         # then
-        self.assertEqual(repr(v1), "RuntimeVersion.from_string('1.2.0')")
+        self.assertEqual(result, "RuntimeVersion.from_string('1.2.0')")
         self.assertEqual(eval(result), v1)
 
     def test_simple(self):

--- a/okonomiyaki/versions/tests/test_runtime_version.py
+++ b/okonomiyaki/versions/tests/test_runtime_version.py
@@ -1,6 +1,6 @@
 import sys
 
-from ..runtime_version import RuntimeVersion, PEP440Version
+from ..runtime_version import RuntimeVersion
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest

--- a/okonomiyaki/versions/tests/test_runtime_version.py
+++ b/okonomiyaki/versions/tests/test_runtime_version.py
@@ -1,6 +1,6 @@
 import sys
 
-from ..runtime_version import RuntimeVersion
+from ..runtime_version import RuntimeVersion, PEP440Version
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -54,6 +54,17 @@ class TestRuntimeVersion(unittest.TestCase):
     def test_str(self):
         self.assertEqual(str(V("1.2.0")), "1.2.0")
         self.assertEqual(V("1.2.0").normalized_string, "1.2")
+
+    def test_repr(self):
+        # given
+        v1 = V("1.2.0")
+
+        # when
+        result = repr(v1)
+
+        # then
+        self.assertEqual(repr(v1), "RuntimeVersion.from_string('1.2.0')")
+        self.assertEqual(eval(result), v1)
 
     def test_simple(self):
         self.assertTrue(V("1.2.0") == V("1.2"))


### PR DESCRIPTION
fixes #435 
fixes #434 

Please note that I ended up using the `from_string` function in the repr because it was the simplest way to have a string that is readable and at the same time reproduce the original object. The RuntimeVersion and PEP440Version will need to be reworked to have something more tranditional in the future