### PR TITLE
Rework and fix platform objects

### DIFF
--- a/okonomiyaki/platforms/__init__.py
+++ b/okonomiyaki/platforms/__init__.py
@@ -1,7 +1,8 @@
 # flake8: noqa
 from .abi import PlatformABI, default_abi
-from .epd_platform import X86, X86_64, EPDPlatform, applies
+from .epd_platform import EPDPlatform, applies
 from ._platform import Platform, OSKind, FamilyKind, NameKind
+from ._arch import X86, X86_64
 from .pep425 import compute_abi_tag, compute_python_tag, compute_platform_tag
 from .python_implementation import PythonABI, PythonImplementation
 

--- a/okonomiyaki/platforms/_arch.py
+++ b/okonomiyaki/platforms/_arch.py
@@ -111,4 +111,3 @@ class Arch(object):
 
 X86 = Arch(ArchitectureKind.x86)
 X86_64 = Arch(ArchitectureKind.x86_64)
-ARM64 = Arch(ArchitectureKind.arm64)

--- a/okonomiyaki/platforms/_arch.py
+++ b/okonomiyaki/platforms/_arch.py
@@ -107,3 +107,8 @@ class Arch(object):
 
     def __str__(self):
         return self.name
+
+
+X86 = Arch(ArchitectureKind.x86)
+X86_64 = Arch(ArchitectureKind.x86_64)
+ARM64 = Arch(ArchitectureKind.arm64)

--- a/okonomiyaki/platforms/_platform.py
+++ b/okonomiyaki/platforms/_platform.py
@@ -99,7 +99,8 @@ class Platform(object):
         """ Guess the platform, using the running python to guess the
         architecture.
         """
-        return _guess_platform()
+        arch = Arch.from_running_python()
+        return _guess_platform(arch)
 
     @classmethod
     def from_running_system(cls, arch_string=None):
@@ -110,7 +111,11 @@ class Platform(object):
         arch_string: str, None
             If given, should be a valid architecture name (e.g. 'x86')
         """
-        return _guess_platform(arch_string)
+        if arch_string is None:
+            arch = Arch.from_running_system()
+        else:
+            arch = Arch.from_name(arch_string)
+        return _guess_platform(arch)
 
     @property
     def family(self):
@@ -172,16 +177,10 @@ def _guess_platform_details(os_kind):
             return family_kind, name_kind, release
 
 
-def _guess_platform(arch_string=None):
-    if arch_string is None:
-        arch = Arch.from_running_python()
-    else:
-        arch = Arch.from_name(arch_string)
-
+def _guess_platform(arch):
     machine = Arch.from_running_system()
     os_kind = _guess_os_kind()
     family_kind, name_kind, release = _guess_platform_details(os_kind)
-
     return Platform(os_kind, name_kind, family_kind, release, arch, machine)
 
 

--- a/okonomiyaki/platforms/_platform.py
+++ b/okonomiyaki/platforms/_platform.py
@@ -13,7 +13,7 @@ from attr.validators import instance_of
 from okonomiyaki.errors import OkonomiyakiError
 from okonomiyaki.versions import SemanticVersion
 
-from ._arch import Arch
+from ._arch import Arch, X86
 
 
 @enum.unique
@@ -132,14 +132,12 @@ class Platform(object):
     def __repr__(self):
         return (
             "Platform(os={0.os!r}, name={0.name!r}, family={0.family!r}, "
-            "release='{0.release}', arch='{0.arch}', machine='{0.machine}')".format(self)
-        )
+            "release='{0.release}', arch='{0.arch}', machine='{0.machine}')".format(self))
 
     def __str__(self):
         return u"{0} {1.release} on {1.machine}".format(
             NAME_KIND_TO_PRETTY_NAMES[self.name_kind],
-            self
-        )
+            self)
 
 
 def _guess_os_kind():
@@ -165,8 +163,7 @@ def _guess_platform_details(os_kind):
             name_kind = NameKind[name]
         except KeyError:
             raise OkonomiyakiError(
-                "Unsupported platform: {0!r}".format(name)
-            )
+                "Unsupported platform: {0!r}".format(name))
         else:
             if name_kind in (NameKind.ubuntu, NameKind.debian):
                 family_kind = FamilyKind.debian
@@ -179,6 +176,8 @@ def _guess_platform_details(os_kind):
 
 def _guess_platform(arch):
     machine = Arch.from_running_system()
+    if machine == X86 and arch.bits == 64:
+        raise OkonomiyakiError("Incompatible 32bit machine with a 64bit architecture")
     os_kind = _guess_os_kind()
     family_kind, name_kind, release = _guess_platform_details(os_kind)
     return Platform(os_kind, name_kind, family_kind, release, arch, machine)

--- a/okonomiyaki/platforms/_platform.py
+++ b/okonomiyaki/platforms/_platform.py
@@ -197,6 +197,7 @@ def _linux_distribution():
     name = name.split()[0]
     return name.lower(), release
 
+
 def _macos_release():
     release = platform.mac_ver()[0]
     if release == '10.16':

--- a/okonomiyaki/platforms/abi.py
+++ b/okonomiyaki/platforms/abi.py
@@ -45,9 +45,9 @@ def _default_cpython_abi(platform, implementation_version):
                 abi = u"msvc2010"
             elif implementation_version.minor <= 6:
                 abi = u"msvc2015"
-            elif implementation_version.minor <= 8:
+            elif implementation_version.minor == 8:
                 abi = u"msvc2019"
-            elif implementation_version.minor <= 11:
+            elif implementation_version.minor == 11:
                 abi = u"msvc2022"
 
         if abi is None:

--- a/okonomiyaki/platforms/abi.py
+++ b/okonomiyaki/platforms/abi.py
@@ -45,9 +45,9 @@ def _default_cpython_abi(platform, implementation_version):
                 abi = u"msvc2010"
             elif implementation_version.minor <= 6:
                 abi = u"msvc2015"
-            elif implementation_version.minor == 8:
+            elif implementation_version.minor <= 8:
                 abi = u"msvc2019"
-            elif implementation_version.minor == 11:
+            elif implementation_version.minor <= 11:
                 abi = u"msvc2022"
 
         if abi is None:

--- a/okonomiyaki/platforms/abi.py
+++ b/okonomiyaki/platforms/abi.py
@@ -47,6 +47,8 @@ def _default_cpython_abi(platform, implementation_version):
                 abi = u"msvc2015"
             elif implementation_version.minor <= 8:
                 abi = u"msvc2019"
+            elif implementation_version.minor <= 11:
+                abi = u"msvc2022"
 
         if abi is None:
             raise OkonomiyakiError(msg)
@@ -115,5 +117,4 @@ def default_abi(platform, implementation, implementation_version):
             raise OkonomiyakiError(msg)
     else:
         raise OkonomiyakiError(
-            "Unsupported implementation: {0!r}".format(implementation)
-        )
+            "Unsupported implementation: {0!r}".format(implementation))

--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -429,7 +429,7 @@ def _epd_name_and_python_to_quadruplet(name, runtime_version=None):
     py38 = RuntimeVersion.from_string('3.8')
     py311 = RuntimeVersion.from_string('3.11')
     if name == "rh8":
-        return (OSKind.linux, NameKind.rhel, FamilyKind.rhel, "8.7")
+        return (OSKind.linux, NameKind.rhel, FamilyKind.rhel, "8.8")
     if name == "rh7":
         return (OSKind.linux, NameKind.rhel, FamilyKind.rhel, "7.1")
     if name == "rh6":

--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -10,7 +10,7 @@ from attr.validators import instance_of
 
 from okonomiyaki.versions import RuntimeVersion
 from okonomiyaki.errors import OkonomiyakiError, InvalidPEP440Version
-from ._arch import Arch, ArchitectureKind
+from ._arch import Arch, ArchitectureKind, X86, X86_64, ARM64
 from ._platform import OSKind, FamilyKind, NameKind, Platform
 
 # the string used in EGG-INFO/spec/depend. Only used during normalization
@@ -26,15 +26,13 @@ _ARCHBITS_TO_ARCH = {
     ArchitectureKind.x86_64: _X86_64_LEGACY_SPEC,
 }
 
-X86 = Arch(ArchitectureKind.x86)
-X86_64 = Arch(ArchitectureKind.x86_64)
-
 PLATFORM_NAMES = (
     "osx",
     "rh3",
     "rh5",
     "rh6",
     "rh7",
+    "rh8",
     "sol",
     "win",
 )
@@ -76,8 +74,7 @@ def platform_validator():
         instance_of(Platform)(inst, attr, value)
         if not _is_supported(value):
             raise OkonomiyakiError(
-                "Platform {0} not supported".format(value)
-            )
+                "Platform {0} not supported by EPD".format(value))
     return wrapper
 
 
@@ -110,7 +107,7 @@ class EPDPlatform(object):
     @classmethod
     def from_running_python(cls):
         """
-        Attempt to create an EPDPlatform instance by guessing the running
+        Attempt to create an EPDPlatform instance based on the running
         python. May raise an OkonomiyakiError exception
         """
         return cls(Platform.from_running_python())
@@ -118,8 +115,8 @@ class EPDPlatform(object):
     @classmethod
     def from_running_system(cls, arch_name=None):
         """
-        Attempt to create an EPDPlatform instance by guessing the running
-        platform. May raise an OkonomiyakiError exception
+        Attempt to create an EPDPlatform instance based on the running platform.
+        May raise an OkonomiyakiError exception
 
         Parameters
         ----------
@@ -127,11 +124,8 @@ class EPDPlatform(object):
             If given, must be a valid architecture string (e.g. 'x86'). If
             None, will be guessed from the running platform.
         """
-        if arch_name is not None:
-            arch = Arch.from_name(arch_name)
-        else:
-            arch = Arch.from_running_system()
-        return _guess_epd_platform(arch)
+        platform = Platform.from_running_system(arch_name)
+        return cls(platform)
 
     @classmethod
     def from_string(cls, s, runtime_version=None):
@@ -173,8 +167,7 @@ class EPDPlatform(object):
         """
         warnings.warn(
             "Deprecated: use EPDPlatform.from_string instead",
-            DeprecationWarning
-        )
+            DeprecationWarning)
         return cls.from_string(s, runtime_version)
 
     @classmethod
@@ -197,6 +190,8 @@ class EPDPlatform(object):
                 epd_name = "rh6"
             elif osdist == "RedHat_7":
                 epd_name = "rh7"
+            elif osdist == "RedHat_8":
+                epd_name = "rh8"
             else:
                 raise ValueError(msg)
         else:
@@ -226,8 +221,7 @@ class EPDPlatform(object):
         """
         if platform_tag is None or platform_tag == _ANY_PLATFORM_STRING:
             raise ValueError(
-                "Invalid platform_tag for platform: '{}'".format(platform_tag)
-            )
+                "Invalid platform_tag for platform: '{}'".format(platform_tag))
         else:
             if platform_tag.startswith("linux"):
                 m = _LINUX_TAG_R.match(platform_tag)
@@ -249,8 +243,7 @@ class EPDPlatform(object):
                     epd_string = u"win_" + str(Arch.from_name(arch_string))
             else:
                 raise NotImplementedError(
-                    "Unsupported platform '{0}'".format(platform_tag)
-                )
+                    "Unsupported platform '{0}'".format(platform_tag))
 
             return cls.from_epd_string(epd_string)
 
@@ -267,7 +260,7 @@ class EPDPlatform(object):
 
     @property
     def pep425_tag(self):
-        msg = "Cannot guess platform tag for platform {0!r}"
+        msg = "Cannot generate pep425 tag for platform {0!r}"
 
         platform = self.platform
         if platform.os_kind == OSKind.darwin:
@@ -276,6 +269,8 @@ class EPDPlatform(object):
                 return u"macosx_{}_i386".format(release)
             elif platform.arch == X86_64:
                 return u"macosx_{}_x86_64".format(release)
+            elif platform.arch == ARM64:
+                return u"macosx_{}_arm64".format(release)
             else:
                 raise OkonomiyakiError(msg.format(platform))
         elif platform.os_kind == OSKind.linux:
@@ -283,6 +278,8 @@ class EPDPlatform(object):
                 return u"linux_i686"
             elif platform.arch == X86_64:
                 return u"linux_x86_64"
+            elif platform.arch == ARM64:
+                return u"linux_aarch64"
             else:
                 raise OkonomiyakiError(msg.format(platform))
         elif platform.os_kind == OSKind.windows:
@@ -290,6 +287,8 @@ class EPDPlatform(object):
                 return u"win32"
             elif platform.arch == X86_64:
                 return u"win_amd64"
+            elif platform.arch == ARM64:
+                return u"win_arm64"
             else:
                 raise OkonomiyakiError(msg.format(platform))
         else:
@@ -315,6 +314,8 @@ class EPDPlatform(object):
                     base = u"rh6"
                 elif parts[0] == "7":
                     base = u"rh7"
+                elif parts[0] == "8":
+                    base = u"rh8"
                 else:
                     msg = ("Unsupported rhel release: {0!r}".format(release))
                     raise OkonomiyakiError(msg)
@@ -330,7 +331,11 @@ class EPDPlatform(object):
 
     @property
     def short(self):
-        return u"{0}-{1}".format(self.platform_name, self.arch_bits)
+        if self.arch in (X86, X86_64):
+            return u"{0}-{1}".format(self.platform_name, self.arch_bits)
+        else:
+            raise ValueError(f'No legacy short name available for {self}')
+
 
     def __str__(self):
         return u"{0.platform_name}_{0.arch}".format(self)
@@ -352,6 +357,7 @@ class EPDPlatform(object):
 def applies(platform_string, to='current'):
     """ Returns True if the given platform string applies to the platform
     specified by 'to'."""
+
     def _parse_component(component):
         component = component.strip()
 
@@ -431,6 +437,9 @@ def applies(platform_string, to='current'):
 
 def _epd_name_and_python_to_quadruplet(name, runtime_version=None):
     py38 = RuntimeVersion.from_string('3.8')
+    py311 = RuntimeVersion.from_string('3.11')
+    if name == "rh8":
+        return (OSKind.linux, NameKind.rhel, FamilyKind.rhel, "8.7")
     if name == "rh7":
         return (OSKind.linux, NameKind.rhel, FamilyKind.rhel, "7.1")
     if name == "rh6":
@@ -440,6 +449,8 @@ def _epd_name_and_python_to_quadruplet(name, runtime_version=None):
     elif name == "rh3":
         return (OSKind.linux, NameKind.rhel, FamilyKind.rhel, "3.8")
     elif name == "osx":
+        if runtime_version is not None and runtime_version >= py311:
+            return (OSKind.darwin, NameKind.mac_os_x, FamilyKind.mac_os_x, "12.0")
         if runtime_version is not None and runtime_version >= py38:
             return (OSKind.darwin, NameKind.mac_os_x, FamilyKind.mac_os_x, "10.14")
         else:
@@ -456,30 +467,24 @@ def _epd_name_and_python_to_quadruplet(name, runtime_version=None):
         raise OkonomiyakiError(msg)
 
 
-def _guess_epd_platform(arch=None):
-    if arch is None:
-        arch = Arch.from_running_python()
-
-    platform = Platform.from_running_system(str(arch))
-    return EPDPlatform(platform)
-
-
 def _is_supported(platform):
     arch_and_machine_are_intel = (
         platform.arch in (X86, X86_64)
-        and platform.machine in (X86, X86_64)
-    )
+        and platform.machine in (X86, X86_64))
+    arch_and_machine_are_arm = (
+        platform.arch == ARM64 and platform.machine == ARM64)
     if platform.os_kind == OSKind.windows:
-        return arch_and_machine_are_intel
+        return arch_and_machine_are_intel or arch_and_machine_are_arm
     if platform.os_kind == OSKind.darwin:
-        return arch_and_machine_are_intel
+        return arch_and_machine_are_intel or arch_and_machine_are_arm
     if platform.os_kind == OSKind.solaris:
         return arch_and_machine_are_intel
     if platform.os_kind == OSKind.linux:
         if platform.family_kind != FamilyKind.rhel:
             return False
         parts = platform.release.split(".")
-        return parts[0] in ("3", "5", "6", "7") \
-            and arch_and_machine_are_intel
+        return (
+            parts[0] in ("3", "5", "6", "7", "8")
+            and arch_and_machine_are_intel)
 
     return False

--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -325,11 +325,7 @@ class EPDPlatform(object):
 
     @property
     def short(self):
-        if self.arch in (X86, X86_64):
-            return u"{0}-{1}".format(self.platform_name, self.arch_bits)
-        else:
-            raise ValueError(f'No legacy short name available for {self}')
-
+        return u"{0}-{1}".format(self.platform_name, self.arch_bits)
 
     def __str__(self):
         return u"{0.platform_name}_{0.arch}".format(self)

--- a/okonomiyaki/platforms/epd_platform.py
+++ b/okonomiyaki/platforms/epd_platform.py
@@ -10,7 +10,7 @@ from attr.validators import instance_of
 
 from okonomiyaki.versions import RuntimeVersion
 from okonomiyaki.errors import OkonomiyakiError, InvalidPEP440Version
-from ._arch import Arch, ArchitectureKind, X86, X86_64, ARM64
+from ._arch import Arch, ArchitectureKind, X86, X86_64
 from ._platform import OSKind, FamilyKind, NameKind, Platform
 
 # the string used in EGG-INFO/spec/depend. Only used during normalization
@@ -269,8 +269,6 @@ class EPDPlatform(object):
                 return u"macosx_{}_i386".format(release)
             elif platform.arch == X86_64:
                 return u"macosx_{}_x86_64".format(release)
-            elif platform.arch == ARM64:
-                return u"macosx_{}_arm64".format(release)
             else:
                 raise OkonomiyakiError(msg.format(platform))
         elif platform.os_kind == OSKind.linux:
@@ -278,8 +276,6 @@ class EPDPlatform(object):
                 return u"linux_i686"
             elif platform.arch == X86_64:
                 return u"linux_x86_64"
-            elif platform.arch == ARM64:
-                return u"linux_aarch64"
             else:
                 raise OkonomiyakiError(msg.format(platform))
         elif platform.os_kind == OSKind.windows:
@@ -287,8 +283,6 @@ class EPDPlatform(object):
                 return u"win32"
             elif platform.arch == X86_64:
                 return u"win_amd64"
-            elif platform.arch == ARM64:
-                return u"win_arm64"
             else:
                 raise OkonomiyakiError(msg.format(platform))
         else:
@@ -471,12 +465,10 @@ def _is_supported(platform):
     arch_and_machine_are_intel = (
         platform.arch in (X86, X86_64)
         and platform.machine in (X86, X86_64))
-    arch_and_machine_are_arm = (
-        platform.arch == ARM64 and platform.machine == ARM64)
     if platform.os_kind == OSKind.windows:
-        return arch_and_machine_are_intel or arch_and_machine_are_arm
+        return arch_and_machine_are_intel
     if platform.os_kind == OSKind.darwin:
-        return arch_and_machine_are_intel or arch_and_machine_are_arm
+        return arch_and_machine_are_intel
     if platform.os_kind == OSKind.solaris:
         return arch_and_machine_are_intel
     if platform.os_kind == OSKind.linux:

--- a/okonomiyaki/platforms/tests/common.py
+++ b/okonomiyaki/platforms/tests/common.py
@@ -94,9 +94,31 @@ mock_windows_7 = MultiPatcher([
                lambda: ("7", "6.1.7601", "SP1", "Multiprocessor Free"))
 ])
 
+mock_windows_10 = MultiPatcher([
+    mock.patch("sys.platform", "win32"),
+    mock.patch("platform.win32_ver",
+               lambda: ('10', '10.0.19041', 'SP0', 'Multiprocessor Free'))
+])
+
+mock_windows_11 = MultiPatcher([
+    mock.patch("sys.platform", "win32"),
+    mock.patch("platform.win32_ver",
+               lambda: ('10', '10.0.22621', 'SP0', 'Multiprocessor Free'))
+])
+
 mock_osx_10_7 = MultiPatcher([
     mock.patch("sys.platform", "darwin"),
     mock.patch("platform.mac_ver", lambda: ("10.7.5", ("", "", ""), "x86_64")),
+])
+
+mock_osx_12_6 = MultiPatcher([
+    mock.patch("sys.platform", "darwin"),
+    mock.patch("platform.mac_ver", lambda: ("12.6.5", ("", "", ""), "x86_64")),
+])
+
+mock_osx_12_6_arm64 = MultiPatcher([
+    mock.patch("sys.platform", "darwin"),
+    mock.patch("platform.mac_ver", lambda: ("12.6.5", ("", "", ""), "arm64")),
 ])
 
 
@@ -109,10 +131,12 @@ mock_machine_x86 = Patcher(mock_machine("x86"))
 mock_architecture_32bit = Patcher(mock.patch("sys.maxsize", 2**32 - 1))
 
 mock_machine_x86_64 = Patcher(mock_machine("x86_64"))
+mock_machine_arm64 = Patcher(mock_machine("ARM64"))
 mock_architecture_64bit = Patcher(mock.patch("sys.maxsize", 2**64 - 1))
 
 mock_x86 = MultiPatcher([mock_machine_x86, mock_architecture_32bit])
 mock_x86_64 = MultiPatcher([mock_machine_x86_64, mock_architecture_64bit])
+mock_arm64 = MultiPatcher([mock_machine_arm64, mock_architecture_64bit])
 # A 32 bits python process on a 64 bits OS
 mock_x86_on_x86_64 = MultiPatcher([mock_machine_x86_64,
                                    mock_architecture_32bit])

--- a/okonomiyaki/platforms/tests/common.py
+++ b/okonomiyaki/platforms/tests/common.py
@@ -116,11 +116,6 @@ mock_osx_12_6 = MultiPatcher([
     mock.patch("platform.mac_ver", lambda: ("12.6.5", ("", "", ""), "x86_64")),
 ])
 
-mock_osx_12_6_arm64 = MultiPatcher([
-    mock.patch("sys.platform", "darwin"),
-    mock.patch("platform.mac_ver", lambda: ("12.6.5", ("", "", ""), "arm64")),
-])
-
 
 # Architecture mocking
 def mock_machine(machine):
@@ -131,14 +126,10 @@ mock_machine_x86 = Patcher(mock_machine("x86"))
 mock_architecture_32bit = Patcher(mock.patch("sys.maxsize", 2**32 - 1))
 
 mock_machine_x86_64 = Patcher(mock_machine("x86_64"))
-mock_machine_arm64 = Patcher(mock_machine("ARM64"))
 mock_architecture_64bit = Patcher(mock.patch("sys.maxsize", 2**64 - 1))
 
 mock_x86 = MultiPatcher([mock_machine_x86, mock_architecture_32bit])
 mock_x86_64 = MultiPatcher([mock_machine_x86_64, mock_architecture_64bit])
-mock_arm64 = MultiPatcher([mock_machine_arm64, mock_architecture_64bit])
 # A 32 bits python process on a 64 bits OS
 mock_x86_on_x86_64 = MultiPatcher([mock_machine_x86_64,
                                    mock_architecture_32bit])
-
-mock_machine_armv71 = Patcher(mock_machine("armv71"))

--- a/okonomiyaki/platforms/tests/common.py
+++ b/okonomiyaki/platforms/tests/common.py
@@ -133,3 +133,5 @@ mock_x86_64 = MultiPatcher([mock_machine_x86_64, mock_architecture_64bit])
 # A 32 bits python process on a 64 bits OS
 mock_x86_on_x86_64 = MultiPatcher([mock_machine_x86_64,
                                    mock_architecture_32bit])
+
+mock_machine_armv71 = Patcher(mock_machine("armv71"))

--- a/okonomiyaki/platforms/tests/test__arch.py
+++ b/okonomiyaki/platforms/tests/test__arch.py
@@ -3,8 +3,8 @@ import sys
 from okonomiyaki.errors import OkonomiyakiError
 from .._arch import Arch
 
-from .common import (mock_machine_armv71, mock_x86, mock_x86_64,
-                     mock_x86_on_x86_64)
+from .common import (
+    mock_x86, mock_x86_64, mock_x86_on_x86_64)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -96,11 +96,6 @@ class TestArch(unittest.TestCase):
         self.assertEqual(arch.name, "x86")
         self.assertEqual(arch.bits, 32)
 
-        # Given/When/Then
-        with mock_machine_armv71:
-            with self.assertRaises(OkonomiyakiError):
-                arch = Arch.from_running_python()
-
     def test_from_running_system(self):
         # When
         with mock_x86:
@@ -125,11 +120,6 @@ class TestArch(unittest.TestCase):
         # Then
         self.assertEqual(arch.name, "x86_64")
         self.assertEqual(arch.bits, 64)
-
-        # Given/When/Then
-        with mock_machine_armv71:
-            with self.assertRaises(OkonomiyakiError):
-                arch = Arch.from_running_system()
 
     def test__legacy_name(self):
         # Given

--- a/okonomiyaki/platforms/tests/test__arch.py
+++ b/okonomiyaki/platforms/tests/test__arch.py
@@ -4,7 +4,7 @@ from okonomiyaki.errors import OkonomiyakiError
 from .._arch import Arch
 
 from .common import (
-    mock_x86, mock_x86_64, mock_x86_on_x86_64)
+    mock_machine_armv71, mock_x86, mock_x86_64, mock_x86_on_x86_64)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -96,6 +96,11 @@ class TestArch(unittest.TestCase):
         self.assertEqual(arch.name, "x86")
         self.assertEqual(arch.bits, 32)
 
+        # Given/When/Then
+        with mock_machine_armv71:
+            with self.assertRaises(OkonomiyakiError):
+                arch = Arch.from_running_python()
+
     def test_from_running_system(self):
         # When
         with mock_x86:
@@ -120,6 +125,11 @@ class TestArch(unittest.TestCase):
         # Then
         self.assertEqual(arch.name, "x86_64")
         self.assertEqual(arch.bits, 64)
+
+        # Given/When/Then
+        with mock_machine_armv71:
+            with self.assertRaises(OkonomiyakiError):
+                arch = Arch.from_running_system()
 
     def test__legacy_name(self):
         # Given

--- a/okonomiyaki/platforms/tests/test_abi.py
+++ b/okonomiyaki/platforms/tests/test_abi.py
@@ -40,7 +40,7 @@ class TestDefaultABI(unittest.TestCase):
 
     @given(
         sampled_from([
-            ("win_x86", "cpython", "3.9.0+1"),
+            ("win_x86", "cpython", "3.12.0+1"),
             ("win_x86", "pypy", "4.1.0+1"),
             ("rh5_x86_64", "r", "3.0.0+1")]))
     def test_non_supported(self, arguments):

--- a/okonomiyaki/platforms/tests/test_epd_platform.py
+++ b/okonomiyaki/platforms/tests/test_epd_platform.py
@@ -1,4 +1,3 @@
-import mock
 import sys
 
 import six

--- a/okonomiyaki/platforms/tests/test_epd_platform.py
+++ b/okonomiyaki/platforms/tests/test_epd_platform.py
@@ -16,7 +16,7 @@ from .._platform import OSKind, FamilyKind, NameKind
 from .common import (
     mock_architecture_32bit, mock_architecture_64bit, mock_centos_5_8,
     mock_centos_6_3, mock_darwin, mock_machine_x86, mock_machine_x86_64,
-    mock_solaris, mock_ubuntu_raring, mock_windows, mock_x86, mock_x86_64,
+    mock_solaris, mock_ubuntu_raring, mock_x86, mock_x86_64,
     mock_centos_7_6, mock_windows_10, mock_windows_11, mock_windows_7)
 
 if sys.version_info < (2, 7):

--- a/okonomiyaki/platforms/tests/test_epd_platform.py
+++ b/okonomiyaki/platforms/tests/test_epd_platform.py
@@ -17,7 +17,7 @@ from .common import (
     mock_architecture_32bit, mock_architecture_64bit, mock_centos_5_8,
     mock_centos_6_3, mock_darwin, mock_machine_x86, mock_machine_x86_64,
     mock_solaris, mock_ubuntu_raring, mock_windows, mock_x86, mock_x86_64,
-    mock_centos_7_6)
+    mock_centos_7_6, mock_windows_10, mock_windows_11, mock_windows_7)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -144,8 +144,46 @@ class TestEPDPlatform(unittest.TestCase):
         # Then
         self.assertEqual(str(epd_platform), "osx_x86_64")
 
-    @mock_windows
-    def test_from_running_system_windows(self):
+    @mock_windows_7
+    def test_from_running_system_windows_7(self):
+        with mock_machine_x86:
+            epd_platform = EPDPlatform.from_running_system()
+            self.assertEqual(str(epd_platform), "win_x86")
+
+            epd_platform = EPDPlatform.from_running_system('x86')
+            self.assertEqual(str(epd_platform), "win_x86")
+
+            with self.assertRaises(OkonomiyakiError):
+                EPDPlatform.from_running_system('AMD64')
+
+        with mock_machine_x86_64:
+            epd_platform = EPDPlatform.from_running_system()
+            self.assertEqual(str(epd_platform), "win_x86_64")
+
+            epd_platform = EPDPlatform.from_running_system('x86')
+            self.assertEqual(str(epd_platform), "win_x86")
+
+    @mock_windows_10
+    def test_from_running_system_windows_10(self):
+        with mock_machine_x86:
+            epd_platform = EPDPlatform.from_running_system()
+            self.assertEqual(str(epd_platform), "win_x86")
+
+            epd_platform = EPDPlatform.from_running_system('x86')
+            self.assertEqual(str(epd_platform), "win_x86")
+
+            with self.assertRaises(OkonomiyakiError):
+                EPDPlatform.from_running_system('AMD64')
+
+        with mock_machine_x86_64:
+            epd_platform = EPDPlatform.from_running_system()
+            self.assertEqual(str(epd_platform), "win_x86_64")
+
+            epd_platform = EPDPlatform.from_running_system('x86')
+            self.assertEqual(str(epd_platform), "win_x86")
+
+    @mock_windows_11
+    def test_from_running_system_windows_11(self):
         with mock_machine_x86:
             epd_platform = EPDPlatform.from_running_system()
             self.assertEqual(str(epd_platform), "win_x86")
@@ -381,9 +419,25 @@ class TestEPDPlatformApplies(unittest.TestCase):
             self.assertTrue(applies("rh5-64", "current"))
             self.assertFalse(applies("!rh5-64", "current"))
 
-    @mock_windows
+    @mock_windows_7
     @mock_x86
-    def test_current_windows(self):
+    def test_current_windows_7(self):
+        for platform in ("rh5", "rh", "osx-32"):
+            self.assertFalse(applies(platform, "current"))
+        for platform in ("win", "win-32"):
+            self.assertTrue(applies(platform, "current"))
+
+    @mock_windows_10
+    @mock_x86
+    def test_current_windows_10(self):
+        for platform in ("rh5", "rh", "osx-32"):
+            self.assertFalse(applies(platform, "current"))
+        for platform in ("win", "win-32"):
+            self.assertTrue(applies(platform, "current"))
+
+    @mock_windows_11
+    @mock_x86
+    def test_current_windows_11(self):
         for platform in ("rh5", "rh", "osx-32"):
             self.assertFalse(applies(platform, "current"))
         for platform in ("win", "win-32"):

--- a/okonomiyaki/platforms/tests/test_platform.py
+++ b/okonomiyaki/platforms/tests/test_platform.py
@@ -4,11 +4,15 @@ from okonomiyaki.errors import OkonomiyakiError
 from ..epd_platform import EPDPlatform
 from .._platform import Platform
 
-from .common import (mock_machine_armv71, mock_x86, mock_x86_64,
-                     mock_machine_x86_64)
-from .common import (mock_architecture_64bit, mock_centos_3_5, mock_centos_5_8,
-                     mock_centos_6_3, mock_osx_10_7, mock_solaris,
-                     mock_ubuntu_raring, mock_windows_7)
+from .common import (
+    mock_machine_armv71, mock_x86, mock_x86_64,
+    mock_machine_x86_64, mock_arm64, mock_architecture_64bit)
+from .common import (
+    mock_centos_3_5, mock_centos_5_8,
+    mock_centos_6_3, mock_osx_10_7, mock_solaris,
+    mock_osx_12_6, mock_osx_12_6_arm64,
+    mock_ubuntu_raring, mock_windows_7, mock_windows_10,
+    mock_windows_11)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -17,6 +21,128 @@ else:
 
 
 class TestPlatformRunningPython(unittest.TestCase):
+
+    @mock_windows_7
+    @mock_x86
+    def test_windows7(self):
+        # When
+        platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "windows")
+        self.assertEqual(platform.name, "windows")
+        self.assertEqual(platform.family, "windows")
+        self.assertEqual(platform.release, "7")
+        self.assertEqual(str(platform), "Windows 7 on x86")
+
+
+    @mock_windows_10
+    @mock_x86_64
+    def test_windows10(self):
+        # When
+        platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "windows")
+        self.assertEqual(platform.name, "windows")
+        self.assertEqual(platform.family, "windows")
+        self.assertEqual(platform.release, "10")
+        self.assertEqual(str(platform), "Windows 10 on x86_64")
+
+    @mock_windows_11
+    @mock_x86_64
+    def test_windows11(self):
+        # When
+        platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "windows")
+        self.assertEqual(platform.name, "windows")
+        self.assertEqual(platform.family, "windows")
+        self.assertEqual(platform.release, "11")
+        self.assertEqual(str(platform), "Windows 11 on x86_64")
+
+    @mock_windows_11
+    @mock_arm64
+    def test_windows11_arm(self):
+        # When
+        platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "windows")
+        self.assertEqual(platform.name, "windows")
+        self.assertEqual(platform.family, "windows")
+        self.assertEqual(platform.release, "11")
+        self.assertEqual(str(platform), "Windows 11 on arm64")
+
+    @mock_osx_10_7
+    @mock_x86
+    def test_osx_10_7(self):
+        # When
+        platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "darwin")
+        self.assertEqual(platform.name, "mac_os_x")
+        self.assertEqual(platform.family, "mac_os_x")
+        self.assertEqual(str(platform), "Mac OS X 10.7.5 on x86")
+
+    @mock_osx_12_6
+    @mock_x86_64
+    def test_osx_12(self):
+        # When
+        platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "darwin")
+        self.assertEqual(platform.name, "mac_os_x")
+        self.assertEqual(platform.family, "mac_os_x")
+        self.assertEqual(str(platform), "Mac OS X 12.6.5 on x86_64")
+
+    @mock_osx_12_6_arm64
+    @mock_arm64
+    def test_osx_12_arm64(self):
+        # When
+        platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "darwin")
+        self.assertEqual(platform.name, "mac_os_x")
+        self.assertEqual(platform.family, "mac_os_x")
+        self.assertEqual(str(platform), "Mac OS X 12.6.5 on arm64")
+
+    @mock_solaris
+    @mock_x86_64
+    def test_solaris(self):
+        # When/Then
+        with self.assertRaises(OkonomiyakiError):
+            Platform.from_running_python()
+
+
+    @mock_centos_3_5
+    def test_centos_3_5(self):
+        # When
+        with mock_x86:
+            platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "linux")
+        self.assertEqual(platform.name, "centos")
+        self.assertEqual(platform.family, "rhel")
+        self.assertEqual(platform.release, "3.5")
+        self.assertEqual(str(platform), "CentOS 3.5 on x86")
+
+        # When
+        with mock_x86_64:
+            platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "linux")
+        self.assertEqual(platform.name, "centos")
+        self.assertEqual(platform.family, "rhel")
+        self.assertEqual(platform.release, "3.5")
+        self.assertEqual(str(platform), "CentOS 3.5 on x86_64")
+
     @mock_centos_5_8
     @mock_x86
     def test_centos_5_8(self):
@@ -32,8 +158,38 @@ class TestPlatformRunningPython(unittest.TestCase):
         self.assertEqual(
             repr(platform),
             "Platform(os='linux', name='centos', family='rhel', release='5.8', "
-            "arch='x86', machine='x86')"
-        )
+            "arch='x86', machine='x86')")
+
+    @mock_centos_6_3
+    def test_centos_6_3(self):
+        # When
+        with mock_x86:
+            platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "linux")
+        self.assertEqual(platform.name, "centos")
+        self.assertEqual(platform.family, "rhel")
+        self.assertEqual(platform.release, "6.3")
+        self.assertEqual(str(platform), "CentOS 6.3 on x86")
+
+        # When
+        with mock_x86_64:
+            platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, "linux")
+        self.assertEqual(platform.name, "centos")
+        self.assertEqual(platform.family, "rhel")
+        self.assertEqual(platform.release, "6.3")
+        self.assertEqual(str(platform), "CentOS 6.3 on x86_64")
+
+    @mock_centos_6_3
+    @mock_machine_armv71
+    def test_centos_6_3_arm(self):
+        # When/Then
+        with self.assertRaises(OkonomiyakiError):
+            Platform.from_running_python()
 
     @mock_ubuntu_raring
     @mock_x86
@@ -49,39 +205,11 @@ class TestPlatformRunningPython(unittest.TestCase):
         self.assertEqual(
             repr(platform),
             "Platform(os='linux', name='ubuntu', family='debian', release='13.04', "
-            "arch='x86', machine='x86')"
-        )
-
-        with self.assertRaises(OkonomiyakiError):
-            EPDPlatform(platform)
-
-    @mock_windows_7
-    @mock_x86
-    def test_windows7(self):
-        # When
-        platform = Platform.from_running_python()
-
-        # Then
-        self.assertEqual(platform.os, "windows")
-        self.assertEqual(platform.name, "windows")
-        self.assertEqual(platform.family, "windows")
-        self.assertEqual(platform.release, "7")
-        self.assertEqual(str(platform), "Windows 7 on x86")
-
-    @mock_osx_10_7
-    @mock_x86
-    def test_osx_10_7(self):
-        # When
-        platform = Platform.from_running_python()
-
-        # Then
-        self.assertEqual(platform.os, "darwin")
-        self.assertEqual(platform.name, "mac_os_x")
-        self.assertEqual(platform.family, "mac_os_x")
-        self.assertEqual(str(platform), "Mac OS X 10.7.5 on x86")
+            "arch='x86', machine='x86')")
 
 
 class TestPlatformRunningSystem(unittest.TestCase):
+
     @mock_windows_7
     @mock_machine_x86_64
     def test_windows7(self):
@@ -93,6 +221,7 @@ class TestPlatformRunningSystem(unittest.TestCase):
             platform = Platform.from_running_system(arch_string)
 
         # Then
+        self.assertEqual(platform.os, "windows")
         self.assertEqual(platform.arch.name, "x86_64")
         self.assertEqual(platform.machine.name, "x86_64")
 
@@ -103,6 +232,7 @@ class TestPlatformRunningSystem(unittest.TestCase):
         platform = Platform.from_running_system(arch_string)
 
         # Then
+        self.assertEqual(platform.os, "windows")
         self.assertEqual(platform.arch.name, "x86_64")
         self.assertEqual(platform.machine.name, "x86_64")
 
@@ -113,85 +243,13 @@ class TestPlatformRunningSystem(unittest.TestCase):
         platform = Platform.from_running_system(arch_string)
 
         # Then
+        self.assertEqual(platform.os, "windows")
         self.assertEqual(platform.arch.name, "x86")
         self.assertEqual(platform.machine.name, "x86_64")
 
 
-class TestEpdPlatform(unittest.TestCase):
-    @mock_centos_3_5
-    def test_centos_3_5(self):
-        # When
-        with mock_x86:
-            platform = Platform.from_running_python()
-
-        # Then
-        self.assertEqual(EPDPlatform(platform).short, "rh3-32")
-
-        # When
-        with mock_x86_64:
-            platform = Platform.from_running_python()
-
-        # Then
-        self.assertEqual(EPDPlatform(platform).short, "rh3-64")
-
-    @mock_centos_5_8
-    def test_centos_5_8(self):
-        # When
-        with mock_x86:
-            platform = Platform.from_running_python()
-
-        # Then
-        self.assertEqual(EPDPlatform(platform).short, "rh5-32")
-
-        # When
-        with mock_x86_64:
-            platform = Platform.from_running_python()
-
-        # Then
-        self.assertEqual(EPDPlatform(platform).short, "rh5-64")
-
-    @mock_centos_6_3
-    def test_centos_6_3(self):
-        # When
-        with mock_x86:
-            platform = Platform.from_running_python()
-
-        # Then
-        self.assertEqual(EPDPlatform(platform).short, "rh6-32")
-
-        # When
-        with mock_x86_64:
-            platform = Platform.from_running_python()
-
-        # Then
-        self.assertEqual(EPDPlatform(platform).short, "rh6-64")
-
-    @mock_centos_6_3
-    @mock_machine_armv71
-    def test_centos_6_3_arm(self):
-        # When/Then
-        with self.assertRaises(OkonomiyakiError):
-            Platform.from_running_python()
-
-    @mock_ubuntu_raring
-    def test_ubuntu_raring(self):
-        # When
-        with mock_x86:
-            platform = Platform.from_running_python()
-
-        # Then
-        with self.assertRaises(OkonomiyakiError):
-            EPDPlatform(platform)
-
-    @mock_solaris
-    @mock_x86_64
-    def test_solaris(self):
-        # When/Then
-        with self.assertRaises(OkonomiyakiError):
-            Platform.from_running_python()
-
-
 class TestPlatform(unittest.TestCase):
+
     @mock_windows_7
     def test_hashing(self):
         # Given

--- a/okonomiyaki/platforms/tests/test_platform.py
+++ b/okonomiyaki/platforms/tests/test_platform.py
@@ -10,7 +10,7 @@ from .common import (
 from .common import (
     mock_centos_3_5, mock_centos_5_8,
     mock_centos_6_3, mock_osx_10_7, mock_solaris,
-    mock_osx_12_6,
+    mock_osx_12_6, ,
     mock_ubuntu_raring, mock_windows_7, mock_windows_10,
     mock_windows_11)
 
@@ -156,6 +156,13 @@ class TestPlatformRunningPython(unittest.TestCase):
         self.assertEqual(platform.family, "rhel")
         self.assertEqual(platform.release, "6.3")
         self.assertEqual(str(platform), "CentOS 6.3 on x86_64")
+
+    @mock_centos_6_3
+    @mock_machine_armv71
+    def test_centos_6_3_arm(self):
+        # When/Then
+        with self.assertRaises(OkonomiyakiError):
+            Platform.from_running_python()
 
     @mock_ubuntu_raring
     @mock_x86

--- a/okonomiyaki/platforms/tests/test_platform.py
+++ b/okonomiyaki/platforms/tests/test_platform.py
@@ -6,7 +6,8 @@ from .._platform import Platform
 
 from .common import (
     mock_machine_armv71, mock_x86, mock_x86_64,
-    mock_machine_x86_64, mock_arm64, mock_architecture_64bit)
+    mock_machine_x86, mock_machine_x86_64, mock_arm64,
+    mock_architecture_64bit)
 from .common import (
     mock_centos_3_5, mock_centos_5_8,
     mock_centos_6_3, mock_osx_10_7, mock_solaris,
@@ -246,6 +247,39 @@ class TestPlatformRunningSystem(unittest.TestCase):
         self.assertEqual(platform.os, "windows")
         self.assertEqual(platform.arch.name, "x86")
         self.assertEqual(platform.machine.name, "x86_64")
+
+    @mock_windows_7
+    @mock_x86
+    def test_windows7_32bit(self):
+        # Given
+        arch_string = None
+
+        # When/Then
+        with mock_architecture_64bit:
+            platform = Platform.from_running_system(arch_string)
+
+        # Then
+        self.assertEqual(platform.os, "windows")
+        self.assertEqual(platform.arch.name, "x86")
+        self.assertEqual(platform.machine.name, "x86")
+
+        # Given
+        arch_string = "x86_64"
+
+        # When/Then
+        with self.assertRaises(OkonomiyakiError):
+            Platform.from_running_system(arch_string)
+
+        # Given
+        arch_string = "x86"
+
+        # When
+        platform = Platform.from_running_system(arch_string)
+
+        # Then
+        self.assertEqual(platform.os, "windows")
+        self.assertEqual(platform.arch.name, "x86")
+        self.assertEqual(platform.machine.name, "x86")
 
 
 class TestPlatform(unittest.TestCase):

--- a/okonomiyaki/platforms/tests/test_platform.py
+++ b/okonomiyaki/platforms/tests/test_platform.py
@@ -8,11 +8,10 @@ from .common import (
     mock_machine_x86_64,
     mock_architecture_64bit)
 from .common import (
-    mock_centos_3_5, mock_centos_5_8,
+    mock_centos_3_5, mock_centos_5_8, mock_machine_armv71,
     mock_centos_6_3, mock_osx_10_7, mock_solaris,
-    mock_osx_12_6, ,
-    mock_ubuntu_raring, mock_windows_7, mock_windows_10,
-    mock_windows_11)
+    mock_osx_12_6, mock_ubuntu_raring, mock_windows_7,
+    mock_windows_10, mock_windows_11)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest

--- a/okonomiyaki/platforms/tests/test_platform.py
+++ b/okonomiyaki/platforms/tests/test_platform.py
@@ -1,17 +1,16 @@
 import sys
 
 from okonomiyaki.errors import OkonomiyakiError
-from ..epd_platform import EPDPlatform
 from .._platform import Platform
 
 from .common import (
-    mock_machine_armv71, mock_x86, mock_x86_64,
-    mock_machine_x86, mock_machine_x86_64, mock_arm64,
+    mock_x86, mock_x86_64,
+    mock_machine_x86_64,
     mock_architecture_64bit)
 from .common import (
     mock_centos_3_5, mock_centos_5_8,
     mock_centos_6_3, mock_osx_10_7, mock_solaris,
-    mock_osx_12_6, mock_osx_12_6_arm64,
+    mock_osx_12_6,
     mock_ubuntu_raring, mock_windows_7, mock_windows_10,
     mock_windows_11)
 
@@ -35,7 +34,6 @@ class TestPlatformRunningPython(unittest.TestCase):
         self.assertEqual(platform.family, "windows")
         self.assertEqual(platform.release, "7")
         self.assertEqual(str(platform), "Windows 7 on x86")
-
 
     @mock_windows_10
     @mock_x86_64
@@ -63,19 +61,6 @@ class TestPlatformRunningPython(unittest.TestCase):
         self.assertEqual(platform.release, "11")
         self.assertEqual(str(platform), "Windows 11 on x86_64")
 
-    @mock_windows_11
-    @mock_arm64
-    def test_windows11_arm(self):
-        # When
-        platform = Platform.from_running_python()
-
-        # Then
-        self.assertEqual(platform.os, "windows")
-        self.assertEqual(platform.name, "windows")
-        self.assertEqual(platform.family, "windows")
-        self.assertEqual(platform.release, "11")
-        self.assertEqual(str(platform), "Windows 11 on arm64")
-
     @mock_osx_10_7
     @mock_x86
     def test_osx_10_7(self):
@@ -100,25 +85,12 @@ class TestPlatformRunningPython(unittest.TestCase):
         self.assertEqual(platform.family, "mac_os_x")
         self.assertEqual(str(platform), "Mac OS X 12.6.5 on x86_64")
 
-    @mock_osx_12_6_arm64
-    @mock_arm64
-    def test_osx_12_arm64(self):
-        # When
-        platform = Platform.from_running_python()
-
-        # Then
-        self.assertEqual(platform.os, "darwin")
-        self.assertEqual(platform.name, "mac_os_x")
-        self.assertEqual(platform.family, "mac_os_x")
-        self.assertEqual(str(platform), "Mac OS X 12.6.5 on arm64")
-
     @mock_solaris
     @mock_x86_64
     def test_solaris(self):
         # When/Then
         with self.assertRaises(OkonomiyakiError):
             Platform.from_running_python()
-
 
     @mock_centos_3_5
     def test_centos_3_5(self):
@@ -184,13 +156,6 @@ class TestPlatformRunningPython(unittest.TestCase):
         self.assertEqual(platform.family, "rhel")
         self.assertEqual(platform.release, "6.3")
         self.assertEqual(str(platform), "CentOS 6.3 on x86_64")
-
-    @mock_centos_6_3
-    @mock_machine_armv71
-    def test_centos_6_3_arm(self):
-        # When/Then
-        with self.assertRaises(OkonomiyakiError):
-            Platform.from_running_python()
 
     @mock_ubuntu_raring
     @mock_x86


### PR DESCRIPTION
- Move the X86 and X86_64 objects to the _arch module where the belong
- Update macos version detection to detect more recent verions of macOS
- Update windows version detection to better separate between windows 10 and windows 11
- Add rh8 linux distribution support
- Add support for cp311 in EPDPlatform
- Augment and cleanup tests