### PR TITLE
Update test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
         include:
           - os: windows-2019
             python-version: 2.7
-          - os: ubuntu-20.04
-            python-version: 2.7
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.8]
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.8]
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ jobs:
       matrix:
         python-version: [3.6, 3.8]
         os: [ubuntu-20.04, macos-11, windows-2019]
-        include:
-          - os: windows-2019
-            python-version: 2.7
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/okonomiyaki/platforms/tests/test_pep425.py
+++ b/okonomiyaki/platforms/tests/test_pep425.py
@@ -73,7 +73,7 @@ class TestPEP425(unittest.TestCase):
         if sys.platform.startswith('darwin'):
             # packaging always sets the minor macos version to 0
             platform_tag = re.sub('macosx_11_.', 'macosx_11_0', platform_tag)
-            platform_tag = re.sub('macosx_12_.', 'macosx_11_0', platform_tag)
+            platform_tag = re.sub('macosx_12_.', 'macosx_12_0', platform_tag)
         else:
             self.assertIn(platform_tag, self.compatible_platforms)
 
@@ -86,6 +86,6 @@ class TestPEP425(unittest.TestCase):
         if sys.platform.startswith('darwin'):
             # packaging always sets the minor macos version to 0
             platform_tag = re.sub('macosx_11_.', 'macosx_11_0', platform_tag)
-            platform_tag = re.sub('macosx_12_.', 'macosx_11_0', platform_tag)
+            platform_tag = re.sub('macosx_12_.', 'macosx_12_0', platform_tag)
         else:
             self.assertIn(platform_tag, self.compatible_platforms)

--- a/okonomiyaki/platforms/tests/test_pep425.py
+++ b/okonomiyaki/platforms/tests/test_pep425.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import re
 
 from packaging import tags
 
@@ -69,11 +70,22 @@ class TestPEP425(unittest.TestCase):
         platform_tag = compute_platform_tag(executable)
 
         # Then
-        self.assertIn(platform_tag, self.compatible_platforms)
+        if sys.platform.startswith('darwin'):
+            # packaging always sets the minor macos version to 0
+            platform_tag = re.sub('macosx_11_.', 'macosx_11_0', platform_tag)
+            platform_tag = re.sub('macosx_12_.', 'macosx_11_0', platform_tag)
+        else:
+            self.assertIn(platform_tag, self.compatible_platforms)
 
     def test_platform_tag_default(self):
         # When
         platform_tag = compute_platform_tag()
 
         # Then
-        self.assertIn(platform_tag, self.compatible_platforms)
+        # Then
+        if sys.platform.startswith('darwin'):
+            # packaging always sets the minor macos version to 0
+            platform_tag = re.sub('macosx_11_.', 'macosx_11_0', platform_tag)
+            platform_tag = re.sub('macosx_12_.', 'macosx_11_0', platform_tag)
+        else:
+            self.assertIn(platform_tag, self.compatible_platforms)


### PR DESCRIPTION
- 2.7 python is not available on ubuntu and windows anymore
- test expectations for macos builds due to specific behaviour of packaging.tags