### PR TITLE
Do not use legacy epd platform

### DIFF
--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -501,10 +501,7 @@ class LegacySpecDepend(object):
         epd_platform = self._epd_platform
         if epd_platform is None:
             return None
-        elif epd_platform.arch == X86_64:
-            return 'amd64'
-        else:
-            return str(epd_platform.arch)
+        return epd_platform.arch._legacy_name
 
     @property
     def egg_name(self):

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -12,8 +12,7 @@ from okonomiyaki.errors import (
     InvalidEggName, InvalidMetadataField,
     MissingMetadata, UnsupportedMetadata)
 from okonomiyaki.platforms import (
-    EPDPlatform, PlatformABI, PythonABI, PythonImplementation,
-    X86_64)
+    EPDPlatform, PlatformABI, PythonABI, PythonImplementation)
 from okonomiyaki.utils import (
     compute_sha256, decode_if_needed, encode_if_needed, parse_assignments)
 from okonomiyaki.utils.py3compat import StringIO, string_types
@@ -501,7 +500,8 @@ class LegacySpecDepend(object):
         epd_platform = self._epd_platform
         if epd_platform is None:
             return None
-        return epd_platform.arch._legacy_name
+        else:
+            return epd_platform.arch._legacy_name
 
     @property
     def egg_name(self):

--- a/okonomiyaki/file_formats/_egg_info.py
+++ b/okonomiyaki/file_formats/_egg_info.py
@@ -11,9 +11,9 @@ from okonomiyaki.errors import (
     InvalidRequirementString, InvalidRequirementStringHyphen,
     InvalidEggName, InvalidMetadataField,
     MissingMetadata, UnsupportedMetadata)
-from okonomiyaki.platforms.legacy import LegacyEPDPlatform
 from okonomiyaki.platforms import (
-    EPDPlatform, PlatformABI, PythonABI, PythonImplementation)
+    EPDPlatform, PlatformABI, PythonABI, PythonImplementation,
+    X86_64)
 from okonomiyaki.utils import (
     compute_sha256, decode_if_needed, encode_if_needed, parse_assignments)
 from okonomiyaki.utils.py3compat import StringIO, string_types
@@ -421,29 +421,17 @@ class LegacySpecDepend(object):
     List of dependencies for this egg
     """
 
-    _epd_legacy_platform = attr(
-        validator=optional(instance_of(LegacyEPDPlatform))
-    )
-
+    _epd_platform = attr(validator=optional(instance_of(EPDPlatform)))
     _metadata_version = attr(validator=instance_of(MetadataVersion))
 
     @classmethod
     def _from_data(cls, data, epd_platform):
         args = data.copy()
         args[_TAG_METADATA_VERSION] = M(
-            args.get(_TAG_METADATA_VERSION, _METADATA_DEFAULT_VERSION_STRING)
-        )
-
-        if epd_platform is None:
-            _epd_legacy_platform = None
-        else:
-            _epd_legacy_platform = LegacyEPDPlatform(epd_platform)
-        args["_epd_legacy_platform"] = _epd_legacy_platform
-
+            args.get(_TAG_METADATA_VERSION, _METADATA_DEFAULT_VERSION_STRING))
         args[_TAG_PACKAGES] = [
             Requirement.from_spec_string(s)
-            for s in args.get(_TAG_PACKAGES, [])
-        ]
+            for s in args.get(_TAG_PACKAGES, [])]
 
         return cls(
             args["name"],
@@ -455,7 +443,7 @@ class LegacySpecDepend(object):
             args["platform_tag"],
             args["platform_abi"],
             args["packages"],
-            args["_epd_legacy_platform"],
+            epd_platform,
             args["metadata_version"],
         )
 
@@ -510,10 +498,13 @@ class LegacySpecDepend(object):
         """
         Egg architecture.
         """
-        if self._epd_legacy_platform is None:
+        epd_platform = self._epd_platform
+        if epd_platform is None:
             return None
+        elif epd_platform.arch == X86_64:
+            return 'amd64'
         else:
-            return self._epd_legacy_platform.arch._legacy_name
+            return str(epd_platform.arch)
 
     @property
     def egg_name(self):
@@ -524,20 +515,34 @@ class LegacySpecDepend(object):
 
     @property
     def osdist(self):
-        if self._epd_legacy_platform is None:
+        epd_platform = self._epd_platform
+        if epd_platform is None:
             return None
-        else:
-            return self._epd_legacy_platform.osdist
+        name = epd_platform.platform_name
+        if name in ('osx', 'win'):
+            return None
+        elif name == 'sol':
+            return 'Solaris 10'
+        elif name.startswith('rh'):
+            return 'RedHat_{}'.format(name[2:])
 
     @property
     def platform(self):
         """
         The legacy platform name (sys.platform).
         """
-        if self._epd_legacy_platform is None:
+        epd_platform = self._epd_platform
+        if epd_platform is None:
             return None
-        else:
-            return self._epd_legacy_platform.platform
+        name = epd_platform.platform_name
+        if name == 'osx':
+            return 'darwin'
+        elif name == 'win':
+            return 'win32'
+        elif name == 'sol':
+            return 'sunos5'
+        elif name.startswith('rh'):
+            return 'linux2'
 
     @property
     def metadata_version(self):
@@ -640,8 +645,7 @@ def _normalized_info_from_string(spec_depend_string, epd_platform=None,
     else:
         if metadata_version < M("1.2"):
             data[_TAG_PYTHON_PEP425_TAG] = _guess_python_tag(
-                raw_data[_TAG_PYTHON]
-            )
+                raw_data[_TAG_PYTHON])
         else:
             data[_TAG_PYTHON_PEP425_TAG] = raw_data[_TAG_PYTHON_PEP425_TAG]
 
@@ -785,26 +789,16 @@ class EggMetadata(object):
     def _from_spec_depend(cls, spec_depend, pkg_info, summary,
                           metadata_version=None):
         raw_name = spec_depend.name
-
-        version = EnpkgVersion.from_upstream_and_build(spec_depend.version,
-                                                       spec_depend.build)
-
+        version = EnpkgVersion.from_upstream_and_build(
+            spec_depend.version, spec_depend.build)
         python_tag = spec_depend.python_tag
         abi_tag = spec_depend.abi_tag
         platform_abi = spec_depend.platform_abi
-
-        if spec_depend._epd_legacy_platform is None:
-            platform = None
-        else:
-            platform = spec_depend._epd_legacy_platform._epd_platform
-
+        epd_platform = spec_depend._epd_platform
         dependencies = Dependencies(
-            tuple(dep for dep in spec_depend.packages)
-        )
-
+            tuple(dep for dep in spec_depend.packages))
         metadata_version = metadata_version or spec_depend.metadata_version
-
-        return cls(raw_name, version, platform, python_tag, abi_tag,
+        return cls(raw_name, version, epd_platform, python_tag, abi_tag,
                    platform_abi, dependencies, pkg_info, summary,
                    metadata_version)
 
@@ -961,7 +955,6 @@ class EggMetadata(object):
     def pkg_info(self):
         if isinstance(self._pkg_info, six.string_types):
             self._pkg_info = PackageInfo.from_string(self._pkg_info)
-
         return self._pkg_info
 
     @property
@@ -1021,13 +1014,6 @@ class EggMetadata(object):
             raise UnsupportedMetadata(
                 self.metadata_version, msg.format(str(self.metadata_version))
             )
-
-        if self.platform is None:
-            epd_platform = None
-        else:
-            legacy_epd_platform = LegacyEPDPlatform(self.platform)
-            epd_platform = legacy_epd_platform._epd_platform
-
         args = {
             "name": self._raw_name,
             "version": self.upstream_version,
@@ -1040,7 +1026,7 @@ class EggMetadata(object):
             "packages": [six.text_type(p) for p in self.runtime_dependencies],
             "metadata_version": six.text_type(self.metadata_version),
         }
-        return LegacySpecDepend._from_data(args, epd_platform)
+        return LegacySpecDepend._from_data(args, self.platform)
 
     # Public methods
     def dump(self, path):
@@ -1056,11 +1042,9 @@ class EggMetadata(object):
         """
         with zipfile2.ZipFile(path, "w", zipfile2.ZIP_DEFLATED) as zp:
             zp.writestr(
-                _SPEC_DEPEND_LOCATION, self.spec_depend_string.encode()
-            )
+                _SPEC_DEPEND_LOCATION, self.spec_depend_string.encode())
             zp.writestr(
-                _SPEC_SUMMARY_LOCATION, self.summary.encode()
-            )
+                _SPEC_SUMMARY_LOCATION, self.summary.encode())
             if self.pkg_info:
                 self.pkg_info._dump_as_zip(zp)
 
@@ -1080,10 +1064,8 @@ class EggMetadata(object):
             _JSON_PLATFORM_TAG: self.platform_tag,
             _JSON_PLATFORM_ABI_TAG: self.platform_abi_tag,
             _JSON_RUNTIME_DEPENDENCIES: [
-                six.text_type(p) for p in self.runtime_dependencies
-            ],
-            _JSON_SUMMARY: self.summary,
-        }
+                six.text_type(p) for p in self.runtime_dependencies],
+            _JSON_SUMMARY: self.summary}
 
     # Protocol implementations
     def __eq__(self, other):
@@ -1091,12 +1073,10 @@ class EggMetadata(object):
             return (
                 self.spec_depend_string == other.spec_depend_string
                 and self.summary == other.summary
-                and self.pkg_info == other.pkg_info
-            )
+                and self.pkg_info == other.pkg_info)
         else:
             raise TypeError(
-                "Only equality between EggMetadata instances is supported"
-            )
+                "Only equality between EggMetadata instances is supported")
 
     def __ne__(self, other):
         return not self == other

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -20,7 +20,6 @@ from okonomiyaki.utils import tempdir
 from okonomiyaki.utils.test_data import (
     MKL_10_3_RH5_X86_64, NOSE_1_3_4_RH6_X86_64, NOSE_1_3_4_RH5_X86_64)
 from okonomiyaki.platforms import EPDPlatform, PlatformABI
-from okonomiyaki.platforms.legacy import LegacyEPDPlatform
 from okonomiyaki.versions import EnpkgVersion, MetadataVersion
 
 from .._egg_info import (

--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -195,10 +195,6 @@ packages = [
         self.assertEqual(depend.arch, "x86")
         self.assertEqual(depend.platform, "win32")
         self.assertIsNone(depend.osdist)
-        self.assertEqual(
-            depend._epd_legacy_platform,
-            LegacyEPDPlatform.from_epd_platform_string("win-32")
-        )
         self.assertEqual(depend.platform_abi, "msvc2008")
 
     def test_format_1_3(self):
@@ -329,7 +325,7 @@ packages = [
             spec_depend = LegacySpecDepend.from_egg(egg)
 
         # Then
-        self.assertEqual(str(spec_depend._epd_legacy_platform), "win-32")
+        self.assertEqual(spec_depend._epd_platform.pep425_tag, "win32")
 
         # When
         with mock.patch(
@@ -340,7 +336,7 @@ packages = [
                 spec_depend = LegacySpecDepend.from_egg(zp)
 
         # Then
-        self.assertEqual(str(spec_depend._epd_legacy_platform), "win-32")
+        self.assertEqual(spec_depend._epd_platform.pep425_tag, "win32")
 
     def test_missing_spec_depend(self):
         # When/Then


### PR DESCRIPTION
Remove the use of the LegacyEPDPlatform object from the active okonomiyaki code. 

More specifically the legacy entires in the _depend_ metadata are now generated based on a single source of truth; the EPDPlatform object


