### PR TITLE
Generate test coverage when running tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [report]
-omit = 
+omit =
        */okonomiyaki/bundled/*
        */okonomiyaki/versions/pep386.py
        */tests/*
@@ -7,3 +7,4 @@ omit =
 [run]
 branch = True
 source = okonomiyaki
+relative_files = True

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,11 @@ jobs:
         python-version: [3.6, 3.8]
         os: [ubuntu-20.04, macos-11, windows-2019]
     runs-on: ${{ matrix.os }}
+    needs: code-lint
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install okonomiyaki
@@ -25,15 +26,43 @@ jobs:
       run: python -m pip install -r "dev_requirements.txt"
     - name: Test with haas
       run: |
-        cd tools
-        python -m haas okonomiyaki
-        
-  code-lint:
-    runs-on: ubuntu-20.04
+        mkdir testing
+        cd testing
+        coverage run -p -m haas okonomiyaki
+    - name: Upload Coverage info
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-${{matrix.os}}-${{matrix.python-version}}
+        path: .coverage.*  
+  coverage:    
+    runs-on: ubuntu-latest
+    needs: tests
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Download coverage artifacts
+      uses: actions/download-artifact@v4
+      with:
+          pattern: coverage-*
+          merge-multiple: true
+    - name: Install coverage
+      run: pip install coverage
+    - name: Generate coverage report
+      run: |
+          coverage combine
+          coverage report
+          coverage html
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: htmlcov/*
+  code-lint:
+    runs-on: ubuntu-20,04
+    steps:
+    - uses: actions/checkout@v4
     - name: Set up Python 3.6
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.6
     - name: Install flake8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
       run: |
         mkdir testing
         cd testing
-        coverage run -p -m haas okonomiyaki
+        coverage run --rcfile=../.coveragerc -p -m haas okonomiyaki
     - name: Upload Coverage info
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{matrix.os}}-${{matrix.python-version}}
-        path: .coverage.*  
+        path: testing/.coverage.*  
   coverage:    
     runs-on: ubuntu-latest
     needs: tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
       run: pip install coverage
     - name: Generate coverage report
       run: |
+          pip install -e .
           coverage combine
           coverage report
           coverage html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         name: coverage-report
         path: htmlcov/*
   code-lint:
-    runs-on: ubuntu-20,04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install okonomiyaki
-      run: python -m pip install .
+      run: python -m pip install -e .
     - name: Install test dependencies
       run: python -m pip install -r "dev_requirements.txt"
     - name: Test with haas

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,12 @@ jobs:
       run: python -m pip install -r "dev_requirements.txt"
     - name: Test with haas
       run: |
-        mkdir testing
-        cd testing
-        coverage run --rcfile=../.coveragerc -p -m haas okonomiyaki
+        coverage run -p -m haas okonomiyaki
     - name: Upload Coverage info
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{matrix.os}}-${{matrix.python-version}}
-        path: testing/.coverage.*  
+        path: .coverage.*  
   coverage:    
     runs-on: ubuntu-latest
     needs: tests


### PR DESCRIPTION
- Generate test coverage
- Add a step to upload coverage from each job
- Add a job to collect and combine coverage after the tests and generate the coverage report 
- Run the code-lint job before anything else