### PR TITLE
Drop use of deprecated alias assertRaisesRegexp

### DIFF
--- a/okonomiyaki/file_formats/tests/test__egg_info.py
+++ b/okonomiyaki/file_formats/tests/test__egg_info.py
@@ -70,7 +70,7 @@ class TestRequirement(unittest.TestCase):
         self.assertEqual(dependency.build_number, 2)
         self.assertEqual(dependency.strictness, 3)
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 InvalidRequirementStringHyphen,
                 "Invalid requirement string {0!r}:"
                 " Package versions should be separated by whitespace"
@@ -293,7 +293,7 @@ packages = [
             packages = []""")
 
         # When/Then
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             InvalidMetadataField,
             r"^Invalid value for metadata field 'python': u?'a.7'"
         ) as exc:
@@ -635,7 +635,7 @@ class TestParseRawspec(unittest.TestCase):
         spec_string = "metadata_version = '1.0'"
 
         # When/Then
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             InvalidMetadataField, r"^Missing metadata field 'name'"
         ):
             parse_rawspec(spec_string)
@@ -770,7 +770,7 @@ packages = [
 """
 
         # When/Then
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             InvalidMetadataField,
             r"^Invalid value for metadata field 'metadata_version': None"
         ):
@@ -793,7 +793,7 @@ packages = [
 """
 
         # When/Then
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             InvalidMetadataField, r"^Missing metadata field 'platform'"
         ):
             parse_rawspec(spec_s)
@@ -816,7 +816,7 @@ packages = [
 """
 
         # When/Then
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             InvalidMetadataField, r"^Missing metadata field 'python_tag'"
         ):
             parse_rawspec(spec_s)

--- a/okonomiyaki/platforms/tests/test_python_implementation.py
+++ b/okonomiyaki/platforms/tests/test_python_implementation.py
@@ -92,7 +92,7 @@ class TestPythonImplementation(unittest.TestCase):
     def test_from_string_errors(self, data):
         # When/Then
         message = r"^Invalid value for metadata field 'python_tag': '{}'$"
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 InvalidMetadataField, message.format(data)):
             PythonImplementation.from_string(data)
 

--- a/okonomiyaki/runtimes/tests/test_runtime_metadata.py
+++ b/okonomiyaki/runtimes/tests/test_runtime_metadata.py
@@ -298,7 +298,7 @@ class TestRuntimeMetadataFactory(unittest.TestCase):
         path = R_DEFAULT_3_0_0_RH5_X86_64
 
         # When/Then
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 UnsupportedMetadata,
                 r"^No support for language 'r' \(metadata version '1.0'\)"):
             runtime_metadata_factory(path)
@@ -333,7 +333,7 @@ class TestRuntimeMetadataFactory(unittest.TestCase):
         path = INVALID_RUNTIME_NO_METADATA_VERSION
 
         # When/Then
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 MissingMetadata,
                 r"^Missing runtime metadata field 'metadata_version'$"):
             runtime_metadata_factory(path)

--- a/okonomiyaki/versions/tests/test_enpkg_version.py
+++ b/okonomiyaki/versions/tests/test_enpkg_version.py
@@ -68,7 +68,7 @@ class TestEnpkgVersionParsing(unittest.TestCase):
         s = "1.3.0-a"
 
         # When/Then
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             InvalidEnpkgVersion, "Invalid build number: 'a'"
         ):
             EnpkgVersion.from_string(s)

--- a/okonomiyaki/versions/tests/test_semver.py
+++ b/okonomiyaki/versions/tests/test_semver.py
@@ -185,7 +185,7 @@ class TestSemanticVersion(unittest.TestCase):
         )
 
         # When/Then
-        with self.assertRaisesRegexp(InvalidSemanticVersion, r_output):
+        with self.assertRaisesRegex(InvalidSemanticVersion, r_output):
             SemanticVersion.from_string(version_string)
 
     def test_other_object(self):


### PR DESCRIPTION
`assertRaisesRegexp()` is an [deprecated][1] alias that was removed in python 3.12. This replaces all instances with the new name, `assertRaisesRegex()`.

[1]: https://docs.python.org/3.11/library/unittest.html#deprecated-aliases