### PR TITLE
Add Alpine Linux as platform

### DIFF
--- a/okonomiyaki/platforms/_platform.py
+++ b/okonomiyaki/platforms/_platform.py
@@ -26,6 +26,7 @@ class FamilyKind(enum.Enum):
     mac_os_x = 'Mac OS X'
     windows = 'Windows'
     solaris = 'Solaris'
+    alpine = 'Alpine Linux'
 
 
 @enum.unique
@@ -39,6 +40,7 @@ class NameKind(enum.Enum):
     windows = 'Windows'
     solaris = 'Solaris'
     rocky = 'Rocky Linux'
+    alpine = 'Alpine Linux'
 
 
 @attributes(repr=False, frozen=True)
@@ -167,6 +169,8 @@ def _guess_platform_details(os_kind):
             family_kind = FamilyKind.rhel
         elif name_kind == NameKind.unknown and 'debian' in like:
             family_kind = FamilyKind.debian
+        elif name_kind == NameKind.alpine:
+            family_kind = FamilyKind.alpine
         else:
             raise OkonomiyakiError("Unsupported platform: {0!r}".format(name))
         return family_kind, name_kind, release


### PR DESCRIPTION
[Alpine Linux][1] is a small, simple and secure Linux distro that uses musl (instead of the more common glibc) as standard C lib, OpenRC as init system, and the Alpine Package Keeper (apk) as package manager.

Alpine is also introduced as a family, as it fundamentally different to both Debian and Red Hat families of Linux distros. And in fact, with Postmarket OS a notable other Linux distro is based directly on Alpine, so there is in fact a (small) family of distros based on Alpine.

[1]: https://alpinelinux.org/

Note: This is required for passing the unit tests on Alpine Linux.