### PR TITLE
Skip tests on unsupported platforms

### DIFF
--- a/okonomiyaki/runtimes/tests/test_runtime.py
+++ b/okonomiyaki/runtimes/tests/test_runtime.py
@@ -4,7 +4,7 @@ import unittest
 
 from okonomiyaki.platforms import EPDPlatform
 from okonomiyaki.versions import RuntimeVersion
-from okonomiyaki.utils.testing import known_systems
+from okonomiyaki.utils.testing import known_system
 
 from ..runtime import PythonRuntime
 
@@ -16,7 +16,7 @@ NORM_EXECUTABLE = os.path.normpath(sys.executable)
 class TestPythonRuntime(unittest.TestCase):
 
     @unittest.skipIf(
-        not known_systems,
+        not known_system,
         'This test should be executed only on Enthought supported platforms')
     def test_simple_from_running_python(self):
         # When

--- a/okonomiyaki/runtimes/tests/test_runtime.py
+++ b/okonomiyaki/runtimes/tests/test_runtime.py
@@ -1,9 +1,10 @@
-import os.path
 import sys
+import os.path
 import unittest
 
 from okonomiyaki.platforms import EPDPlatform
 from okonomiyaki.versions import RuntimeVersion
+from okonomiyaki.utils.testing import known_systems
 
 from ..runtime import PythonRuntime
 
@@ -13,6 +14,10 @@ NORM_EXECUTABLE = os.path.normpath(sys.executable)
 
 
 class TestPythonRuntime(unittest.TestCase):
+
+    @unittest.skipIf(
+        not known_systems,
+        'This test should be executed only on Enthought supported platforms')
     def test_simple_from_running_python(self):
         # When
         runtime_info = PythonRuntime.from_running_python()

--- a/okonomiyaki/utils/testing.py
+++ b/okonomiyaki/utils/testing.py
@@ -1,4 +1,4 @@
-from okonomyaki.errors import OkonomiyakiError
+from okonomiyaki.errors import OkonomiyakiError
 
 
 class Patcher(object):

--- a/okonomiyaki/utils/testing.py
+++ b/okonomiyaki/utils/testing.py
@@ -1,3 +1,6 @@
+from okonomyaki.errors import OkonomiyakiError
+
+
 class Patcher(object):
     """ A dumb class to allow a mock.patch object to be used as a decorator and
     a context manager
@@ -48,3 +51,16 @@ class MultiPatcher(object):
     def __exit__(self, *a, **kw):
         for patcher in self._patchers:
             patcher.__exit__(*a, **kw)
+
+
+def known_system(self):
+    from okonomiyaki.plarforms._platform import (
+        _guess_os_kind, _guess_platform, _guess_platform_details)
+    try:
+        os_kind = _guess_os_kind()
+        _guess_platform(os_kind)
+        _guess_platform_details(os_kind)
+    except OkonomiyakiError:
+        return False
+    else:
+        return True


### PR DESCRIPTION
fixes #471 

- Add a function to check if the current system is supported/compatible
- Skip `test_simple_from_running_python` on unsupported platforms