### PR TITLE
Better detection of apple silicon arch

### DIFF
--- a/okonomiyaki/platforms/_arch.py
+++ b/okonomiyaki/platforms/_arch.py
@@ -114,7 +114,10 @@ class Arch(object):
 
     @classmethod
     def from_running_system(cls):
-        return Arch.from_name(platform.machine())
+        if platform.system() == 'Darwin' and 'RELEASE_ARM64' in platform.uname().version:
+            return Arch.from_name('arm64')
+        else:
+            return Arch.from_name(platform.machine())
 
     @property
     def bits(self):

--- a/okonomiyaki/platforms/tests/common.py
+++ b/okonomiyaki/platforms/tests/common.py
@@ -70,6 +70,8 @@ mock_machine_invalid = MultiPatcher([
             "MyOS", "localhost", "12.6.5",
             "Super Kernel Version 3 bla bla",
             "PyCPU", "123"))])
+
+
 def _mock_linux_distribution(info):
     return MultiPatcher([
         mock_linux,

--- a/okonomiyaki/platforms/tests/common.py
+++ b/okonomiyaki/platforms/tests/common.py
@@ -18,7 +18,8 @@ mock_darwin = MultiPatcher([
         lambda: uname_result(
             "Darwin", "localhost", "11.4.2",
             "Darwin Kernel Version 11.4.2 bla bla",
-            "x86_64", "i386"))])
+            "x86_64", "i386")),
+    mock.patch("platform.mac_ver", lambda: ("11.4.2", ("", "", ""), "x86_64"))])
 mock_apple_silicon = MultiPatcher([
     mock.patch("sys.platform", "darwin"),
     # These value are there to mask the running system values
@@ -27,7 +28,8 @@ mock_apple_silicon = MultiPatcher([
         lambda: uname_result(
             "Darwin", "localhost", "22.6.0",
             "Darwin Kernel Version 22.6.0 bla bla",
-            "RELEASE_ARM64_BLABLA", "arm64"))])
+            "RELEASE_ARM64_BLABLA", "arm64")),
+    mock.patch("platform.mac_ver", lambda: ("22.6.0", ("", "", ""), "arm64"))])
 mock_linux = MultiPatcher([
     mock.patch("sys.platform", "linux2"),
     # These value are there to mask the running system values

--- a/okonomiyaki/platforms/tests/common.py
+++ b/okonomiyaki/platforms/tests/common.py
@@ -19,6 +19,15 @@ mock_darwin = MultiPatcher([
             "Darwin", "localhost", "11.4.2",
             "Darwin Kernel Version 11.4.2 bla bla",
             "x86_64", "i386"))])
+mock_apple_silicon = MultiPatcher([
+    mock.patch("sys.platform", "darwin"),
+    # These value are there to mask the running system values
+    mock.patch(
+        "platform.uname",
+        lambda: uname_result(
+            "Darwin", "localhost", "22.6.0",
+            "Darwin Kernel Version 22.6.0 bla bla",
+            "RELEASE_ARM64_BLABLA", "arm64"))])
 mock_linux = MultiPatcher([
     mock.patch("sys.platform", "linux2"),
     # These value are there to mask the running system values
@@ -43,13 +52,24 @@ mock_windows = MultiPatcher([
         lambda: uname_result(
             'Windows', 'localhost', '7', '6.1.7601',
             'x86', ('x86 Family 6 Model 4 5 Stepping 7, GenuineIntel')))])
-
 mock_osx_12_6_arm64 = MultiPatcher([
     mock.patch("sys.platform", "darwin"),
-    mock.patch("platform.mac_ver", lambda: ("12.6.5", ("", "", ""), "arm64")),
-])
-
-
+    mock.patch(
+        "platform.uname",
+        lambda: uname_result(
+            "Darwin", "localhost", "12.6.5",
+            "Darwin Kernel Version 12.6.5 bla bla",
+            "x86_64", "i386")),
+    mock.patch("platform.mac_ver", lambda: ("12.6.5", ("", "", ""), "arm64"))])
+mock_machine_invalid = MultiPatcher([
+    mock.patch("sys.platform", "darwin"),
+    mock.patch("platform.machine", lambda: "PyCPU"),
+    mock.patch(
+        "platform.uname",
+        lambda: uname_result(
+            "MyOS", "localhost", "12.6.5",
+            "Super Kernel Version 3 bla bla",
+            "PyCPU", "123"))])
 def _mock_linux_distribution(info):
     return MultiPatcher([
         mock_linux,
@@ -70,29 +90,56 @@ mock_ubuntu_raring = _mock_linux_distribution(("Ubuntu", "13.04", "raring", "deb
 
 mock_windows_7 = MultiPatcher([
     mock.patch("sys.platform", "win32"),
+    mock.patch(
+        "platform.uname",
+        lambda: uname_result(
+            'Windows', 'localhost', '7', '6.1.7601',
+            'x86', ('x86 Family 6 Model 4 5 Stepping 7, GenuineIntel'))),
     mock.patch("platform.win32_ver",
                lambda: ("7", "6.1.7601", "SP1", "Multiprocessor Free"))
 ])
 
 mock_windows_10 = MultiPatcher([
     mock.patch("sys.platform", "win32"),
+    mock.patch(
+        "platform.uname",
+        lambda: uname_result(
+            'Windows', 'localhost', '10', '120000',
+            'x86_64', ('x86 Family 6 Model 4 5 Stepping 7, GenuineIntel'))),
     mock.patch("platform.win32_ver",
                lambda: ('10', '10.0.19041', 'SP0', 'Multiprocessor Free'))
 ])
 
 mock_windows_11 = MultiPatcher([
     mock.patch("sys.platform", "win32"),
+    mock.patch(
+        "platform.uname",
+        lambda: uname_result(
+            'Windows', 'localhost', '11', '120000',
+            'x86_64', ('x86 Family 6 Model 4 5 Stepping 7, GenuineIntel'))),
     mock.patch("platform.win32_ver",
                lambda: ('10', '10.0.22621', 'SP0', 'Multiprocessor Free'))
 ])
 
 mock_osx_10_7 = MultiPatcher([
     mock.patch("sys.platform", "darwin"),
+    mock.patch(
+        "platform.uname",
+        lambda: uname_result(
+            "Darwin", "localhost", "10.7.5",
+            "Darwin Kernel Version 10.7.5 bla bla",
+            "x86_64", "i386")),
     mock.patch("platform.mac_ver", lambda: ("10.7.5", ("", "", ""), "x86_64")),
 ])
 
 mock_osx_12_6 = MultiPatcher([
     mock.patch("sys.platform", "darwin"),
+    mock.patch(
+        "platform.uname",
+        lambda: uname_result(
+            "Darwin", "localhost", "12.6.5",
+            "Darwin Kernel Version 12.6.5 bla bla",
+            "x86_64", "i386")),
     mock.patch("platform.mac_ver", lambda: ("12.6.5", ("", "", ""), "x86_64")),
 ])
 
@@ -113,7 +160,6 @@ mock_x86_64 = MultiPatcher([mock_machine_x86_64, mock_architecture_64bit])
 mock_arm64 = MultiPatcher([mock_machine_arm64, mock_architecture_64bit])
 mock_arm = MultiPatcher([mock_machine_arm, mock_architecture_32bit])
 mock_machine_armv71 = Patcher(mock_machine("ARMv7"))
-mock_machine_invalid = Patcher(mock_machine("MyCPU"))
 # A 32 bits python process on a 64 bits OS
 mock_x86_on_x86_64 = MultiPatcher(
     [mock_machine_x86_64, mock_architecture_32bit])

--- a/okonomiyaki/platforms/tests/test__arch.py
+++ b/okonomiyaki/platforms/tests/test__arch.py
@@ -83,6 +83,7 @@ class TestArch(unittest.TestCase):
     @parameterized.expand([
         (mock_apple_silicon, mock_arm64, ARM64),
         (mock_apple_silicon, mock_x86_64, X86_64),
+        (mock_darwin, mock_x86_64, X86_64),
         (mock_linux, mock_arm64, ARM64),
         (mock_linux, mock_x86_64, X86_64),
         (mock_linux, mock_arm, ARM),

--- a/okonomiyaki/platforms/tests/test__arch.py
+++ b/okonomiyaki/platforms/tests/test__arch.py
@@ -5,7 +5,8 @@ from parameterized import parameterized
 from okonomiyaki.errors import OkonomiyakiError
 from .._arch import Arch, X86, X86_64, ARM, ARM64
 from .common import (
-    mock_machine_invalid, mock_x86, mock_x86_64, mock_x86_on_x86_64, mock_arm, mock_arm64)
+    mock_machine_invalid, mock_x86, mock_x86_64, mock_x86_on_x86_64, mock_arm, mock_arm64,
+    mock_apple_silicon, mock_darwin, mock_linux, mock_windows)
 
 
 class TestArch(unittest.TestCase):
@@ -80,12 +81,21 @@ class TestArch(unittest.TestCase):
                 Arch.from_running_python()
 
     @parameterized.expand([
-        (mock_x86, X86), (mock_x86_64, X86_64),
-        (mock_arm, ARM), (mock_arm64, ARM64)])
-    def test_from_running_system(self, machine, expected):
+        (mock_apple_silicon, mock_arm64, ARM64),
+        (mock_apple_silicon, mock_x86_64, X86_64),
+        (mock_linux, mock_arm64, ARM64),
+        (mock_linux, mock_x86_64, X86_64),
+        (mock_linux, mock_arm, ARM),
+        (mock_linux, mock_arm64, ARM64),
+        (mock_windows, mock_arm64, ARM64),
+        (mock_windows, mock_x86_64, X86_64),
+        (mock_windows, mock_arm, ARM),
+        (mock_windows, mock_arm64, ARM64)])
+    def test_from_running_system(self, uname, machine, expected):
         # When
-        with machine:
-            arch = Arch.from_running_system()
+        with uname:
+            with machine:
+                arch = Arch.from_running_system()
 
         # Then
         self.assertEqual(arch, expected)

--- a/okonomiyaki/platforms/tests/test_platform.py
+++ b/okonomiyaki/platforms/tests/test_platform.py
@@ -14,7 +14,7 @@ from .common import (
     mock_centos_6_3, mock_osx_10_7, mock_solaris,
     mock_osx_12_6, mock_ubuntu_raring, mock_windows_7,
     mock_windows_10, mock_windows_11, mock_mydistro_2_8,
-    mock_rocky_8_8)
+    mock_rocky_8_8, mock_apple_silicon)
 
 
 class TestPlatformRunningPython(unittest.TestCase):
@@ -68,6 +68,23 @@ class TestPlatformRunningPython(unittest.TestCase):
         self.assertEqual(platform.release, '11')
         self.assertEqual(
             str(platform), f'Windows 11 on {arch} using {arch} arch')
+
+    @parameterized.expand([
+        (mock_x86_64, X86_64),
+        (mock_arm64, ARM64)])
+    @mock_apple_silicon
+    def test_apple_silicon(self, machine, arch):
+        # When
+        with machine:
+            platform = Platform.from_running_python()
+
+        # Then
+        self.assertEqual(platform.os, 'darwin')
+        self.assertEqual(platform.name, 'mac_os_x')
+        self.assertEqual(platform.family, 'mac_os_x')
+        self.assertEqual(platform.release, '13.7.1')
+        self.assertEqual(
+            str(platform), f'Mac OS X 13.7.1 on {arch} using {arch} arch')
 
     @parameterized.expand([
         (mock_x86, X86), (mock_x86_64, X86_64)])

--- a/okonomiyaki/platforms/tests/test_platform.py
+++ b/okonomiyaki/platforms/tests/test_platform.py
@@ -82,9 +82,9 @@ class TestPlatformRunningPython(unittest.TestCase):
         self.assertEqual(platform.os, 'darwin')
         self.assertEqual(platform.name, 'mac_os_x')
         self.assertEqual(platform.family, 'mac_os_x')
-        self.assertEqual(platform.release, '13.7.1')
+        self.assertEqual(platform.release, '22.6.0')
         self.assertEqual(
-            str(platform), f'Mac OS X 13.7.1 on {arch} using {arch} arch')
+            str(platform), f'Mac OS X 22.6.0 on {arch} using {arch} arch')
 
     @parameterized.expand([
         (mock_x86, X86), (mock_x86_64, X86_64)])


### PR DESCRIPTION
- On macos platform.machine will report x86_64 when the running python is executed through Rosetta. So we need to special case the code and workaround this behaviour
- mocks have been also updated to better mask the actual running system when running the tests